### PR TITLE
Add E2E coverage for leave deadline, admin roster, pricing, and 5-1 UI

### DIFF
--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -65,6 +65,8 @@ Payment amount display and non-Bunq paid-state UI can be covered only when the s
 - [ ] E2E-HOME-010: Global Admin sees `Game Administrators` and `Create New Game` controls for non-integration admin access.
 - [ ] E2E-HOME-011: Assigned Admin sees `Create New Game` access without global-only administration links.
 - [ ] E2E-HOME-012: Home error state shows `Error` and `Retry` when the games API fails, then recovers after retry.
+- [ ] E2E-HOME-014: Games home cards use a yellow left border for 5-1 games and a green left border for non-5-1 games.
+- [ ] E2E-HOME-015: Category info blocks on the games home use yellow background for 5-1 and green for other selected categories.
 
 ## Game details participant scenarios
 
@@ -74,17 +76,21 @@ Payment amount display and non-Bunq paid-state UI can be covered only when the s
 - [ ] E2E-GAME-004: Participant B joins a full game and lands on the waiting list with the `Waitlist` status.
 - [ ] E2E-GAME-005: Participant A leaves a full game and the next waitlisted participant moves into the active players list.
 - [ ] E2E-GAME-006: Participant A sees the readonly notice and cannot join or leave when a game is marked readonly.
-- [ ] E2E-GAME-007: Participant A sees deadline or registration-closed info text when the unregister deadline has passed.
+- [ ] E2E-GAME-007: Participant A sees deadline or registration-closed info text when the unregister deadline has passed, and the Leave Game action is not available.
 - [ ] E2E-GAME-008: Participant A opens a non-existent game id and sees `Error`, `Game not found`, and `Back to Games`.
 - [ ] E2E-GAME-009: Participant A registers a guest when guest registration is allowed and sees the guest in the players list.
 - [ ] E2E-GAME-010: Participant A opens and completes the bring-ball dialog when the game state requires ball assignment.
 - [ ] E2E-GAME-011: Participant A sees seasonal game theming for Halloween, New Year, and March 8 tagged games without breaking core registration actions.
+- [ ] E2E-GAME-012: Global Admin opens a past game that had waitlisted players and sees only the main players list (no waiting list section or waitlisted names).
+- [ ] E2E-GAME-014: Participant A opens a Thursday 5-1 game and sees the category notice with 5-1 (yellow) styling on game details.
 
 ## Game creation and editing scenarios
 
 - [ ] E2E-FORM-001: Global Admin opens `Create New Game` from the games home.
 - [ ] E2E-FORM-002: Global Admin creates a standard game with date/time, maximum players, unregister deadline, per-participant cost, location name, optional location link, and optional title.
 - [ ] E2E-FORM-003: Global Admin creates a game with total-cost pricing and sees the per-participant preview update as maximum players changes.
+- [ ] E2E-FORM-010: Global Admin creates a saved total-cost game and sees the calculated per-participant price on game details.
+- [ ] E2E-FORM-011: Global Admin edits a total-cost game and sees the per-participant preview update when maximum players changes.
 - [ ] E2E-FORM-004: Global Admin creates a game with `Playing 5-1` enabled and verifies it appears in the appropriate games list/category behavior.
 - [ ] E2E-FORM-005: Global Admin creates a readonly game and verifies regular participants cannot self-register.
 - [ ] E2E-FORM-006: Global Admin cancels game creation and returns without creating a game.
@@ -102,6 +108,7 @@ Payment amount display and non-Bunq paid-state UI can be covered only when the s
 - [ ] E2E-ADMIN-006: Assigned Admin can manage games for their assigned day/type, including creating a game and reaching permitted admin actions.
 - [ ] E2E-ADMIN-007: Assigned Admin cannot access global-only routes such as game administrator assignment management.
 - [ ] E2E-ADMIN-008: Non-admin Participant A cannot reach create/edit/admin-only screens by direct URL and is redirected or blocked.
+- [ ] E2E-ADMIN-011: Global Admin cannot add or remove players on an upcoming open game (before it is readonly or past).
 
 ## Game administrator assignment scenarios
 

--- a/e2e/game-details-participant.spec.ts
+++ b/e2e/game-details-participant.spec.ts
@@ -157,6 +157,7 @@ test.describe('game details participant scenarios', () => {
     await page.goto(`/game/${game.id}`);
 
     await expect(page.getByText('You can only leave the game up to 5 hours before it starts.')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Leave Game' })).toHaveCount(0);
   });
 
   test('E2E-GAME-008 participant opens a non-existent game id and sees error recovery', async ({ page }, testInfo) => {

--- a/e2e/game-rules-and-display.spec.ts
+++ b/e2e/game-rules-and-display.spec.ts
@@ -1,0 +1,202 @@
+import { expect, test } from '@playwright/test';
+import {
+  cleanupE2eData,
+  createDevUserViaApi,
+  createGameViaUi,
+  daysFromNow,
+  devLogin,
+  devLoginAs,
+  e2eTitle,
+  formatGameDateTimeForInput,
+  nextWeekday,
+  registerForGameViaUi,
+  setCheckbox,
+  switchToUser,
+  waitForAdminGameCreateResponse,
+  waitForBackend,
+} from './support/fixtures';
+
+test.describe('game rules and display scenarios', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await cleanupE2eData();
+  });
+
+  test('E2E-ADMIN-011 global admin cannot add or remove players on upcoming open game', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Open Game Admin', true);
+    const player = await createDevUserViaApi(request, testInfo, 'Open Game Player');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Upcoming Open Admin'),
+      dateTime: daysFromNow(2),
+      maxPlayers: 8,
+    });
+    await registerForGameViaUi(page, player, game.id);
+
+    await switchToUser(page, admin);
+    await page.goto(`/game/${game.id}`);
+
+    await expect(page.locator('.admin-actions').getByTitle('Add Participant')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Remove player' })).toHaveCount(0);
+    await expect(page.getByText(player.displayName)).toBeVisible();
+  });
+
+  test('E2E-GAME-012 past game hides waitlist and shows only main list for admin', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Past Waitlist Admin', true);
+    const activeOne = await createDevUserViaApi(request, testInfo, 'Past Active One');
+    const activeTwo = await createDevUserViaApi(request, testInfo, 'Past Active Two');
+    const waitlisted = await createDevUserViaApi(request, testInfo, 'Past Waitlisted Only');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Past Waitlist Hidden'),
+      dateTime: daysFromNow(-1),
+      maxPlayers: 2,
+    });
+    await registerForGameViaUi(page, activeOne, game.id);
+    await registerForGameViaUi(page, activeTwo, game.id);
+    await registerForGameViaUi(page, waitlisted, game.id, 'Waitlist');
+
+    await switchToUser(page, admin);
+    await page.goto(`/game/${game.id}`);
+
+    await expect(page.getByRole('heading', { name: 'Waiting List' })).toHaveCount(0);
+    await expect(page.getByText(activeOne.displayName)).toBeVisible();
+    await expect(page.getByText(activeTwo.displayName)).toBeVisible();
+    await expect(page.getByText(waitlisted.displayName)).toHaveCount(0);
+    await expect(page.locator('.players-section:not(.waitlist-section) .player-item')).toHaveCount(2);
+  });
+
+  test('E2E-FORM-010 global admin creates total-cost game and sees per-participant price on details', async ({
+    page,
+  }, testInfo) => {
+    const title = e2eTitle(testInfo, 'Total Cost Saved');
+    await devLogin(page, testInfo, 'Total Cost Admin', true);
+    await page.goto('/games/new');
+    const dateInput = page.getByPlaceholder('Select date and time');
+    await dateInput.fill(formatGameDateTimeForInput(daysFromNow(2)));
+    await dateInput.press('Enter');
+    await page.locator('#maxPlayers').fill('10');
+    await page.locator('#unregisterDeadlineHours').fill('5');
+    await setCheckbox(page, '#pricingMode');
+    await page.locator('#paymentAmount').fill('100');
+    await page.locator('#locationName').fill('E2E Total Cost Hall');
+    await page.locator('#locationLink').fill('https://maps.example/e2e-total-cost');
+    await page.locator('#title').fill(title);
+    const createResponsePromise = waitForAdminGameCreateResponse(page);
+    await page.getByRole('button', { name: 'Create Game' }).click();
+    const createResponse = await createResponsePromise;
+    expect(createResponse.ok()).toBeTruthy();
+    const { id } = (await createResponse.json()) as { id: number };
+    await expect(page).toHaveURL('/');
+
+    await page.goto(`/game/${id}`);
+    await expect(page.getByText('€10.00 per participant')).toBeVisible();
+  });
+
+  test('E2E-FORM-011 editing max players updates total-cost per-player preview', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Edit Total Cost Admin', true);
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Edit Total Cost'),
+      dateTime: daysFromNow(2),
+      maxPlayers: 10,
+      paymentAmount: '100',
+      pricingMode: 'total_cost',
+    });
+
+    await page.goto(`/game/${game.id}/edit`);
+    await expect(page.getByText(/€100\.00 ÷ 10 players = €10\.00 per player/)).toBeVisible();
+
+    await page.locator('#maxPlayers').fill('20');
+    await expect(page.getByText(/€100\.00 ÷ 20 players = €5\.00 per player/)).toBeVisible();
+  });
+
+  test('E2E-HOME-014 game cards use yellow border for 5-1 and green for non-5-1 games', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Card Colors Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Card Colors Participant');
+    await devLoginAs(page, admin);
+    const fiveOneTitle = e2eTitle(testInfo, 'Card Five One');
+    const regularTitle = e2eTitle(testInfo, 'Card Deti Plova');
+    const thursday = nextWeekday(4);
+    await createGameViaUi(page, {
+      title: fiveOneTitle,
+      dateTime: thursday,
+      withPositions: true,
+    });
+    await createGameViaUi(page, {
+      title: regularTitle,
+      dateTime: thursday,
+      withPositions: false,
+      maxPlayers: 12,
+    });
+
+    await switchToUser(page, participant);
+    await page.locator('.category-multiselect-trigger').click();
+    await page.locator('label.category-multiselect-option').filter({ hasText: 'Thursday 5-1' }).click();
+    await page.locator('.category-multiselect-trigger').click();
+    await page.locator('label.category-multiselect-option').filter({ hasText: 'Thursday Deti Plova' }).click();
+    await expect(page.getByText(fiveOneTitle)).toBeVisible();
+    await expect(page.getByText(regularTitle)).toBeVisible();
+
+    const fiveOneCard = page.locator('.game-card').filter({ hasText: fiveOneTitle });
+    const regularCard = page.locator('.game-card').filter({ hasText: regularTitle });
+
+    await expect(fiveOneCard).toHaveClass(/with-positions/);
+    await expect(fiveOneCard).not.toHaveClass(/without-positions/);
+    await expect(fiveOneCard).toHaveCSS('border-left-color', 'rgb(255, 193, 7)');
+
+    await expect(regularCard).toHaveClass(/without-positions/);
+    await expect(regularCard).not.toHaveClass(/with-positions/);
+    await expect(regularCard).toHaveCSS('border-left-color', 'rgb(76, 175, 80)');
+  });
+
+  test('E2E-HOME-015 category info blocks use yellow for 5-1 and green for other categories', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Category Colors Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Category Colors Participant');
+    await devLoginAs(page, admin);
+    await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Category Five One'),
+      dateTime: nextWeekday(4),
+      withPositions: true,
+    });
+    await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Category Sunday'),
+      dateTime: nextWeekday(0),
+      withPositions: false,
+    });
+
+    await switchToUser(page, participant);
+    await page.locator('.category-multiselect-trigger').click();
+    await page.locator('label.category-multiselect-option').filter({ hasText: 'Thursday 5-1' }).click();
+
+    const fiveOneBlock = page.locator('.category-info-block').filter({ hasText: 'Thursday 5-1' });
+    await expect(fiveOneBlock).toHaveClass(/with-positions/);
+    await expect(fiveOneBlock).toHaveCSS('background-color', 'rgb(255, 248, 225)');
+
+    const sundayBlock = page.locator('.category-info-block').filter({ hasText: 'Sunday' });
+    await expect(sundayBlock).toHaveClass(/without-positions/);
+    await expect(sundayBlock).toHaveCSS('background-color', 'rgb(232, 245, 233)');
+  });
+
+  test('E2E-GAME-014 game details shows 5-1 category notice with yellow styling', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Details 5-1 Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Details 5-1 Participant');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Details Five One'),
+      dateTime: nextWeekday(4),
+      withPositions: true,
+    });
+
+    await switchToUser(page, participant);
+    await page.goto(`/game/${game.id}`);
+
+    const categoryBlock = page.locator('.category-info-block');
+    await expect(categoryBlock).toContainText('Thursday 5-1');
+    await expect(categoryBlock).toHaveClass(/with-positions/);
+    await expect(categoryBlock).toHaveCSS('background-color', 'rgb(255, 248, 225)');
+  });
+});

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -189,8 +189,8 @@ export async function createGameViaUi(page: Page, input: UiGameInput): Promise<G
   if (input.pricingMode === 'total_cost') {
     await setCheckbox(page, '#pricingMode');
   }
-  if (input.withPositions) {
-    await setCheckbox(page, '#withPositions');
+  if (input.withPositions !== undefined) {
+    await setCheckbox(page, '#withPositions', input.withPositions);
   }
   if (input.readonly) {
     await setCheckbox(page, '#readonly');

--- a/tg-mini-app/src/pages/GameDetails.tsx
+++ b/tg-mini-app/src/pages/GameDetails.tsx
@@ -372,7 +372,7 @@ const GameDetails: React.FC<GameDetailsProps> = ({ user }) => {
           </div>
         ) : null}
 
-        {waitlistRegistrations.length > 0 && (
+        {!isPastGame && waitlistRegistrations.length > 0 && (
           <div className="players-section waitlist-section">
             <h2>Waiting List</h2>
             <WaitlistList


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Playwright coverage for the scenario gaps identified in the E2E audit (excluding payment-request / Bunq flows).

## New tests (`e2e/game-rules-and-display.spec.ts`)

| ID | What it verifies |
|----|------------------|
| **E2E-ADMIN-011** | Global admin cannot add or remove players on an upcoming open game |
| **E2E-GAME-012** | Past game hides the waitlist section; only main-list players are visible to admin |
| **E2E-FORM-010** | Saved total-cost game shows calculated per-participant price on details |
| **E2E-FORM-011** | Editing max players updates total-cost per-player preview on the edit form |
| **E2E-HOME-014** | Game cards use yellow (5-1) vs green (non-5-1) left border colors |
| **E2E-HOME-015** | Category info blocks use yellow vs green backgrounds |
| **E2E-GAME-014** | Game details shows the Thursday 5-1 notice with yellow styling |

## Other changes

- **E2E-GAME-007** (existing): also asserts the Leave Game button is absent after the unregister deadline.
- **`GameDetails.tsx`**: hide the waitlist section when the game is in the past (`!isPastGame`).
- **`createGameViaUi`**: explicitly set `#withPositions` when `withPositions: false`, so a prior Thursday 5-1 game does not prefill the checkbox for the next create.

## Checklist

`docs/playwright-e2e-scenarios.md` updated with the new scenario IDs.

## Not in scope

Payment-request-sent restrictions remain excluded per the existing E2E scope document.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93f60f04-35cd-4a81-b98c-335364ec1cb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93f60f04-35cd-4a81-b98c-335364ec1cb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

