### PR TITLE
test(e2e): implement HOME-015 and BUNQ-STATUS-002–007

### DIFF
--- a/bunq-mock/src/controlApp.ts
+++ b/bunq-mock/src/controlApp.ts
@@ -16,6 +16,17 @@ const MIN_ACCEPTED_BODY = {
   },
 };
 
+function markRequestInquiryAcceptedInState(state: BunqMockState, inquiryId: number): boolean {
+  for (const session of state.sessions.values()) {
+    const row = session.requestInquiries.get(inquiryId);
+    if (row) {
+      row.status = 'ACCEPTED';
+      return true;
+    }
+  }
+  return false;
+}
+
 function controlAuth(expectedToken: string | undefined) {
   return (req: express.Request, res: express.Response, next: express.NextFunction) => {
     if (!expectedToken) {
@@ -75,6 +86,8 @@ export function createControlApp(state: BunqMockState, options?: { controlToken?
       },
     };
 
+    markRequestInquiryAcceptedInState(state, idNum);
+
     try {
       const r = await fetch(targetUrl, {
         method: 'POST',
@@ -92,6 +105,17 @@ export function createControlApp(state: BunqMockState, options?: { controlToken?
       const message = e instanceof Error ? e.message : 'Unknown error';
       res.status(502).json({ error: 'Webhook delivery failed', detail: message, targetUrl });
     }
+  });
+
+  app.post('/request-inquiries/:inquiryId/mark-accepted', (req, res) => {
+    const idNum = parseInt(req.params.inquiryId, 10);
+    if (Number.isNaN(idNum)) {
+      return res.status(400).json({ error: 'inquiryId must be numeric' });
+    }
+    if (!markRequestInquiryAcceptedInState(state, idNum)) {
+      return res.status(404).json({ error: 'Request inquiry not found' });
+    }
+    res.json({ ok: true, inquiryId: idNum, status: 'ACCEPTED' });
   });
 
   app.get('/health', (_req, res) => {

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -70,7 +70,7 @@ Spec: `e2e/games-home.spec.ts`
 - [x] E2E-HOME-012: Home error state shows `Error` and `Retry` when the games API fails, then recovers after retry.
 - [x] E2E-HOME-013: With default category filter (Sunday), participant sees `No games available` when the only upcoming game is a Thursday 5-1 game.
 - [x] E2E-HOME-014: Participant deselects all category options in the multi-select and sees `No games available` even when games exist for other categories.
-- [ ] E2E-HOME-015: Participant A with an unpaid past game (after admin sent payment requests) sees `Your unpaid games` on the upcoming home view, opens the entry, and **Pay now** opens the Bunq payment link in a new browser tab (or window).
+- [x] E2E-HOME-015: Participant A with an unpaid past game (after admin sent payment requests) sees `Your unpaid games` on the upcoming home view, opens the entry, and **Pay now** opens the Bunq payment link in a new browser tab (or window).
 
 ## Game details participant scenarios
 
@@ -203,13 +203,15 @@ Past or readonly games with `paymentAmount > 0`, Bunq enabled for the collecting
 - [x] E2E-BUNQ-PAY-007: Game with zero cost does not show send-payment-requests even when past and Bunq is enabled.
 - [x] E2E-BUNQ-PAY-008: Past game already marked fully paid on the games home does not show send-payment-requests on game details (`fully_paid` set via allowed DB helper in test).
 
-## Bunq payment status scenarios (planned)
+## Bunq payment status scenarios
+
+Spec: `e2e/bunq-status.spec.ts`
 
 Status surfaces: per-player `Paid` / `Unpaid` on game details (past/readonly, after requests sent), **Check payment status for this game** sync button on game details, paid/total counters on past game cards, and `Show fully paid games` on the past filter. Optional bulk route: `/check-payments` (password dialog on load; no in-app nav link today—use only if testing that screen explicitly).
 
-- [ ] E2E-BUNQ-STATUS-002: Global Admin clicks **Check payment status for this game**, enters the Bunq password, sees `Payment check completed`, and unpaid players update to `Paid` when the mock reports inquiry status `ACCEPTED`.
-- [ ] E2E-BUNQ-STATUS-003: Global Admin toggles a player from `Unpaid` to `Paid` and back via the paid-status control on the player row; counts on the games home past list update after refresh.
-- [ ] E2E-BUNQ-STATUS-004: When all active players are paid, the past game card shows matching paid/total counts (e.g. `2/2`); with `Show fully paid games` unchecked, the game is hidden from the past list until the toggle is enabled (extends HOME-009 with Bunq-driven fully-paid state via UI).
-- [ ] E2E-BUNQ-STATUS-005: Wrong password on per-game check keeps the password dialog open with `Invalid password`.
-- [ ] E2E-BUNQ-STATUS-006: Global Admin opens `/check-payments`, submits password on `Enter Bunq API Password`, sees completion feedback, and returns to games home; past unpaid games reflect updated statuses where the mock reports payment accepted.
-- [ ] E2E-BUNQ-STATUS-007: Participant A on a past game they joined does not see admin paid-status toggles or check-payment/sync controls; they may still see price and their own registration state.
+- [x] E2E-BUNQ-STATUS-002: Global Admin clicks **Check payment status for this game**, enters the Bunq password, sees `Payment check completed`, and unpaid players update to `Paid` when the mock reports inquiry status `ACCEPTED`.
+- [x] E2E-BUNQ-STATUS-003: Global Admin toggles a player from `Unpaid` to `Paid` and back via the paid-status control on the player row; counts on the games home past list update after refresh.
+- [x] E2E-BUNQ-STATUS-004: When all active players are paid, the past game card shows matching paid/total counts (e.g. `2/2`); with `Show fully paid games` unchecked, the game is hidden from the past list until the toggle is enabled (extends HOME-009 with Bunq-driven fully-paid state via UI).
+- [x] E2E-BUNQ-STATUS-005: Wrong password on per-game check keeps the password dialog open with `Invalid password`.
+- [x] E2E-BUNQ-STATUS-006: Global Admin opens `/check-payments`, submits password on `Enter Bunq API Password`, sees completion feedback, and returns to games home; past unpaid games reflect updated statuses where the mock reports payment accepted.
+- [x] E2E-BUNQ-STATUS-007: Participant A on a past game they joined does not see admin paid-status toggles or check-payment/sync controls; they may still see price and their own registration state.

--- a/e2e/bunq-status.spec.ts
+++ b/e2e/bunq-status.spec.ts
@@ -1,0 +1,227 @@
+import { expect, test } from '@playwright/test';
+import {
+  addParticipantViaUi,
+  BUNQ_E2E_PASSWORD,
+  cleanupE2eData,
+  createDevUserViaApi,
+  createGameViaUi,
+  daysFromNow,
+  devLoginAs,
+  dismissPaymentCheckCompletedDialog,
+  enableBunqIntegrationViaUi,
+  e2eTitle,
+  getPaymentRequestIdForUserRegistration,
+  markBunqRequestInquiryAccepted,
+  moveGameToPastViaUi,
+  registerForGameViaUi,
+  resetBunqMock,
+  sendPaymentRequestsViaUi,
+  submitCheckPaymentStatusForGame,
+  switchToUser,
+  togglePlayerPaidStatusViaUi,
+  waitForBackend,
+} from './support/fixtures';
+
+test.describe('Bunq payment status scenarios', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await resetBunqMock();
+    await cleanupE2eData();
+  });
+
+  test('E2E-BUNQ-STATUS-002 per-game check marks unpaid players paid when mock reports ACCEPTED', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Status Check Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Status Check Player');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Status Check Game'),
+      dateTime: daysFromNow(2),
+    });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+    await sendPaymentRequestsViaUi(page);
+
+    const inquiryId = await getPaymentRequestIdForUserRegistration(game.id, participant.id);
+    expect(inquiryId).toBeTruthy();
+    await markBunqRequestInquiryAccepted(inquiryId!);
+
+    await submitCheckPaymentStatusForGame(page);
+    await dismissPaymentCheckCompletedDialog(page);
+
+    const row = page.locator('.player-item').filter({ hasText: participant.displayName });
+    await expect(row.getByText('Paid')).toBeVisible();
+  });
+
+  test('E2E-BUNQ-STATUS-003 admin toggles paid status and past list counts update', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Status Toggle Admin', true);
+    const playerA = await createDevUserViaApi(request, testInfo, 'Status Toggle A');
+    const playerB = await createDevUserViaApi(request, testInfo, 'Status Toggle B');
+    const title = e2eTitle(testInfo, 'Status Toggle Game');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title, dateTime: daysFromNow(2) });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, playerA.displayName);
+    await addParticipantViaUi(page, playerB.displayName);
+    await sendPaymentRequestsViaUi(page);
+
+    await togglePlayerPaidStatusViaUi(page, playerA.displayName);
+    await togglePlayerPaidStatusViaUi(page, playerB.displayName);
+
+    await page.goto('/');
+    await page.getByLabel('Past').check();
+    await page.getByLabel('Show fully paid games').check();
+    const card = page.locator('.game-card-wrapper').filter({ hasText: title });
+    await expect(card).toBeVisible();
+    await expect(card.locator('.compact-stats .counter').nth(0)).toHaveText('2');
+    await expect(card.locator('.compact-stats .counter').nth(1)).toHaveText('2');
+
+    await page.goto(`/game/${game.id}`);
+    await togglePlayerPaidStatusViaUi(page, playerA.displayName);
+
+    await page.goto('/');
+    await page.getByLabel('Past').check();
+    await page.getByLabel('Show fully paid games').check();
+    await expect(card.locator('.compact-stats .counter').nth(0)).toHaveText('1');
+    await expect(card.locator('.compact-stats .counter').nth(1)).toHaveText('2');
+  });
+
+  test('E2E-BUNQ-STATUS-004 fully paid past game shows counts and hides until toggle', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Status Fully Paid Admin', true);
+    const playerA = await createDevUserViaApi(request, testInfo, 'Status Fully Paid A');
+    const playerB = await createDevUserViaApi(request, testInfo, 'Status Fully Paid B');
+    const title = e2eTitle(testInfo, 'Status Fully Paid Game');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title, dateTime: daysFromNow(2), maxPlayers: 12 });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, playerA.displayName);
+    await addParticipantViaUi(page, playerB.displayName);
+    await sendPaymentRequestsViaUi(page);
+    await togglePlayerPaidStatusViaUi(page, playerA.displayName);
+    await togglePlayerPaidStatusViaUi(page, playerB.displayName);
+
+    await page.goto('/');
+    await page.getByLabel('Past').check();
+    await page.getByLabel('Show fully paid games').check();
+    const card = page.locator('.game-card-wrapper').filter({ hasText: title });
+    await expect(card).toBeVisible();
+    await expect(card.locator('.compact-stats .counter').nth(0)).toHaveText('2');
+    await expect(card.locator('.compact-stats .counter').nth(1)).toHaveText('2');
+
+    await page.getByLabel('Show fully paid games').uncheck();
+    await expect(page.getByText(title)).toHaveCount(0);
+    await page.getByLabel('Show fully paid games').check();
+    await expect(page.getByText(title)).toBeVisible();
+    await expect(card.locator('.compact-stats .counter').nth(0)).toHaveText('2');
+  });
+
+  test('E2E-BUNQ-STATUS-005 wrong password on per-game check keeps dialog open', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Status Wrong Pass Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Status Wrong Pass Player');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Status Wrong Pass'),
+      dateTime: daysFromNow(2),
+    });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+    await sendPaymentRequestsViaUi(page);
+
+    await submitCheckPaymentStatusForGame(page, 'WrongPassword!9');
+    await expect(page.locator('.password-dialog-overlay')).toBeVisible();
+    await expect(page.locator('.password-dialog-overlay')).toContainText('Invalid password');
+    await expect(page.locator('.dialog-overlay').filter({ hasText: 'Payment check completed' })).toHaveCount(0);
+  });
+
+  test('E2E-BUNQ-STATUS-006 bulk check-payments route updates unpaid past games', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Status Bulk Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Status Bulk Player');
+    const title = e2eTitle(testInfo, 'Status Bulk Game');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title, dateTime: daysFromNow(2) });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+    await sendPaymentRequestsViaUi(page);
+
+    const inquiryId = await getPaymentRequestIdForUserRegistration(game.id, participant.id);
+    expect(inquiryId).toBeTruthy();
+    await markBunqRequestInquiryAccepted(inquiryId!);
+
+    page.once('dialog', async (dialog) => {
+      expect(dialog.type()).toBe('alert');
+      expect(dialog.message()).toMatch(/Payment check completed/i);
+      await dialog.accept();
+    });
+
+    await page.goto('/check-payments');
+    await expect(page.getByRole('heading', { name: 'Enter Bunq API Password' })).toBeVisible();
+    await page.locator('.password-dialog-overlay').getByLabel('Password:').fill(BUNQ_E2E_PASSWORD);
+    await page.locator('.password-dialog-overlay').getByRole('button', { name: 'Submit' }).click();
+
+    await expect(page).toHaveURL('/', { timeout: 60_000 });
+    await page.getByLabel('Past').check();
+    await page.goto(`/game/${game.id}`);
+    const row = page.locator('.player-item').filter({ hasText: participant.displayName });
+    await expect(row.getByText('Paid')).toBeVisible();
+  });
+
+  test('E2E-BUNQ-STATUS-007 participant does not see admin payment controls on past game', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Status Participant Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Status Participant View');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Status Participant Game'),
+      dateTime: daysFromNow(2),
+      paymentAmount: '7.50',
+    });
+
+    await registerForGameViaUi(page, participant, game.id);
+
+    await switchToUser(page, admin);
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await sendPaymentRequestsViaUi(page);
+
+    await switchToUser(page, participant);
+    await page.goto(`/game/${game.id}`);
+
+    await expect(page.getByText('€7.50')).toBeVisible();
+    await expect(page.getByText("You're in", { exact: true })).toBeVisible();
+    await expect(page.getByTitle('Check payment status for this game')).toHaveCount(0);
+    await expect(page.getByTitle('Send payment requests to unpaid players')).toHaveCount(0);
+    await expect(page.locator('.paid-status')).toHaveCount(0);
+  });
+});

--- a/e2e/games-home.spec.ts
+++ b/e2e/games-home.spec.ts
@@ -6,9 +6,13 @@ import {
   daysFromNow,
   devLogin,
   devLoginAs,
+  enableBunqIntegrationViaUi,
   e2eTitle,
+  moveGameToPastViaUi,
   nextWeekday,
   registerForGameViaUi,
+  resetBunqMock,
+  sendPaymentRequestsViaUi,
   switchToUser,
   updateGame,
   waitForBackend,
@@ -256,5 +260,46 @@ test.describe('games home scenarios', () => {
     await page.locator('label.category-multiselect-option').filter({ hasText: 'Sunday' }).click();
 
     await expect(page.getByText('No games available')).toBeVisible();
+  });
+
+  test('E2E-HOME-015 participant sees unpaid games block and Pay now opens payment link', async ({
+    page,
+    request,
+  }, testInfo) => {
+    await resetBunqMock();
+
+    const admin = await createDevUserViaApi(request, testInfo, 'Unpaid Home Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Unpaid Home Participant');
+    const locationName = 'E2E Unpaid Home Hall';
+    const title = e2eTitle(testInfo, 'Unpaid Home Game');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title,
+      dateTime: daysFromNow(2),
+      locationName,
+    });
+
+    await registerForGameViaUi(page, participant, game.id);
+
+    await switchToUser(page, admin);
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await sendPaymentRequestsViaUi(page);
+
+    await switchToUser(page, participant);
+    await page.goto('/');
+
+    await expect(page.getByText('Your unpaid games')).toBeVisible();
+    const unpaidItem = page.locator('.unpaid-item').filter({ hasText: locationName });
+    await expect(unpaidItem).toBeVisible();
+
+    const popupPromise = page.waitForEvent('popup');
+    await unpaidItem.getByRole('button', { name: 'Pay now' }).click();
+    const popup = await popupPromise;
+    await expect(popup).toHaveURL(/bunq\.me\/e2e-mock/);
+    await popup.close();
   });
 });

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -292,6 +292,16 @@ export async function resetBunqMock(): Promise<void> {
   }
 }
 
+export async function markBunqRequestInquiryAccepted(requestInquiryId: string): Promise<void> {
+  const res = await fetch(`${BUNQ_MOCK_CONTROL_ORIGIN}/request-inquiries/${requestInquiryId}/mark-accepted`, {
+    method: 'POST',
+    headers: { 'X-Bunq-Mock-Control-Token': BUNQ_MOCK_CONTROL_TOKEN },
+  });
+  if (!res.ok) {
+    throw new Error(`markBunqRequestInquiryAccepted failed: HTTP ${res.status} ${await res.text()}`);
+  }
+}
+
 export async function deliverBunqRequestInquiryAcceptedWebhook(
   requestInquiryId: string,
   targetUrlOverride?: string
@@ -469,6 +479,48 @@ export async function sendPaymentRequestsViaUi(page: Page, password = BUNQ_E2E_P
   await submitSendPaymentRequestsPassword(page, password);
   await dismissPaymentRequestsSentDialog(page);
   await expect(page.getByText('Payments collected by')).toBeVisible({ timeout: 30_000 });
+}
+
+export async function submitCheckPaymentStatusForGame(page: Page, password = BUNQ_E2E_PASSWORD): Promise<void> {
+  const checkButton = page.locator('.check-payments-button');
+  await expect(checkButton).toBeVisible({ timeout: 30_000 });
+
+  await expect
+    .poll(
+      async () => {
+        await checkButton.click();
+        return page.locator('.password-dialog-overlay #password').isVisible();
+      },
+      { timeout: 15_000, message: 'password dialog should open for per-game payment check' }
+    )
+    .toBe(true);
+
+  await page.locator('.password-dialog-overlay #password').fill(password);
+  await page.locator('.password-dialog-overlay').getByRole('button', { name: 'Submit' }).click();
+}
+
+export async function dismissPaymentCheckCompletedDialog(page: Page): Promise<void> {
+  const dialog = page.locator('.dialog-overlay').filter({ hasText: 'Payment check completed' });
+  await expect(dialog).toBeVisible({ timeout: 60_000 });
+  await dialog.locator('.dialog-btn.ok').click();
+}
+
+export async function confirmDialog(page: Page): Promise<void> {
+  await page.locator('.dialog-overlay .dialog-btn.ok').click();
+}
+
+export async function togglePlayerPaidStatusViaUi(
+  page: Page,
+  displayName: string,
+  options?: { confirm?: boolean }
+): Promise<void> {
+  const confirm = options?.confirm ?? true;
+  const row = page.locator('.player-item').filter({ hasText: displayName });
+  await row.locator('.paid-status').click();
+  if (confirm) {
+    await expect(page.locator('.dialog-overlay .dialog-message')).toContainText(/Mark|Unmark/);
+    await confirmDialog(page);
+  }
 }
 
 export async function getPaymentRequestIdForUserRegistration(gameId: number, userId: number): Promise<string | null> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the seven remaining Playwright scenarios from `docs/playwright-e2e-scenarios.md`:

- **E2E-HOME-015** — participant unpaid-games block and Pay now opens the Bunq payment link
- **E2E-BUNQ-STATUS-002–007** — per-game payment sync, admin paid toggles, fully-paid past list filtering, bulk `/check-payments`, and participant access boundaries

## Changes

- New `e2e/bunq-status.spec.ts` with six Bunq payment-status tests
- `E2E-HOME-015` added to `e2e/games-home.spec.ts`
- Shared helpers in `e2e/support/fixtures.ts` (check-payment submit with action-guard retry, paid-toggle, mock inquiry accept)
- `bunq-mock` control: `POST /request-inquiries/:id/mark-accepted` and webhook delivery now marks mock inquiries `ACCEPTED` for poll-based checks
- Checklist updated: all seven scenarios marked `[x]`

## Testing

```bash
npm run test:e2e -- e2e/bunq-status.spec.ts e2e/games-home.spec.ts -g "E2E-HOME-015|E2E-BUNQ-STATUS"
```

All 7 tests pass locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-241eeb17-9ff2-403b-b2b0-c51c32096b25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-241eeb17-9ff2-403b-b2b0-c51c32096b25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

