### PR TITLE
test(e2e): mark games fully paid via Bunq mock instead of DB helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ docker-data/
 
 # Test & coverage outputs
 .nyc_output/
+playwright-report/
+test-results/
 
 # Yarn Plug'n'Play files (even if project uses npm, these sometimes show up)
 .pnp

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -28,6 +28,7 @@ TELEGRAM_TOPIC_ID=
 # Bunq API
 # Override only if you use a custom endpoint (rare)
 BUNQ_API_URL=https://api.bunq.com/v1
+# E2E / local: bunq-mock listens at http://127.0.0.1:3998/v1 (npm run bunq-mock:dev from repo root).
 
 # Optional: used to build email-like aliases in payment requests
 EMAIL_DOMAIN=volley-game-central.com

--- a/bunq-mock/package-lock.json
+++ b/bunq-mock/package-lock.json
@@ -1,0 +1,1490 @@
+{
+  "name": "bunq-mock",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bunq-mock",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.21.2"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.22",
+        "@types/node": "^20.17.52",
+        "tsx": "^4.19.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.1.tgz",
+      "integrity": "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/bunq-mock/package.json
+++ b/bunq-mock/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "bunq-mock",
+  "private": true,
+  "version": "1.0.0",
+  "description": "In-memory Bunq API simulator and test control server",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "express": "^4.21.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.22",
+    "@types/node": "^20.17.52",
+    "tsx": "^4.19.2",
+    "typescript": "^5.8.3"
+  }
+}

--- a/bunq-mock/src/bunqApiApp.ts
+++ b/bunq-mock/src/bunqApiApp.ts
@@ -1,0 +1,226 @@
+import express, { type Request, type Response, type NextFunction } from 'express';
+import type { BunqMockState, RequestInquiryRow, SessionState } from './state.js';
+import { defaultSessionState, randomInstallationToken, randomSessionToken } from './state.js';
+
+function json(res: Response, body: unknown, status = 200) {
+  res.status(status).json(body);
+}
+
+function getInstallAuth(req: Request): string | undefined {
+  const h = req.headers['x-bunq-client-authentication'];
+  return typeof h === 'string' ? h : undefined;
+}
+
+function requireInstallationAuth(state: BunqMockState) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const tok = getInstallAuth(req);
+    if (!tok || !state.installations.has(tok)) {
+      return json(res, { Error: [{ error_description: 'Invalid installation token' }] }, 401);
+    }
+    (req as express.Request & { installationToken: string }).installationToken = tok;
+    next();
+  };
+}
+
+function requireSessionAuth(state: BunqMockState) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const tok = getInstallAuth(req);
+    if (!tok || !state.sessions.has(tok)) {
+      return json(res, { Error: [{ error_description: 'Invalid session token' }] }, 401);
+    }
+    (req as express.Request & { sessionToken: string }).sessionToken = tok;
+    next();
+  };
+}
+
+function getSession(req: Request, state: BunqMockState): SessionState {
+  const tok = (req as express.Request & { sessionToken: string }).sessionToken;
+  return state.sessions.get(tok)!;
+}
+
+export function createBunqApiApp(state: BunqMockState): express.Express {
+  const app = express();
+  app.use(express.json({ type: ['application/json', 'application/json; charset=utf-8'] }));
+
+  const v1 = express.Router();
+
+  v1.post('/installation', (_req, res) => {
+    const token = randomInstallationToken();
+    state.installations.set(token, { deviceRegistered: false });
+    json(res, {
+      Response: [{ Token: { token } }],
+    });
+  });
+
+  v1.post('/device-server', requireInstallationAuth(state), (req, res) => {
+    const tok = (req as express.Request & { installationToken: string }).installationToken;
+    state.installations.get(tok)!.deviceRegistered = true;
+    json(res, { Response: [] });
+  });
+
+  v1.post('/session-server', requireInstallationAuth(state), (req, res) => {
+    const sessionToken = randomSessionToken();
+    state.sessions.set(sessionToken, defaultSessionState());
+    json(res, {
+      Response: [{ Token: { token: sessionToken } }],
+    });
+  });
+
+  v1.get('/user', requireSessionAuth(state), (req, res) => {
+    const session = getSession(req, state);
+    json(res, {
+      Response: [
+        {
+          UserPerson: {
+            id: session.bunqUserId,
+            display_name: 'E2E Mock User',
+            first_name: 'E2E',
+            last_name: 'Mock',
+          },
+        },
+      ],
+    });
+  });
+
+  v1.get(
+    '/user/:userId/monetary-account',
+    requireSessionAuth(state),
+    (req, res) => {
+      const session = getSession(req, state);
+      const uid = parseInt(req.params.userId, 10);
+      if (uid !== session.bunqUserId) {
+        return json(res, { Error: [{ error_description: 'User id mismatch' }] }, 400);
+      }
+      const Response = session.monetaryAccounts.map((a) => ({
+        MonetaryAccountBank: {
+          id: a.id,
+          description: a.description,
+          status: a.status,
+        },
+      }));
+      json(res, { Response });
+    }
+  );
+
+  v1.post(
+    '/user/:userId/notification-filter-url',
+    requireSessionAuth(state),
+    (req, res) => {
+      const session = getSession(req, state);
+      const uid = parseInt(req.params.userId, 10);
+      if (uid !== session.bunqUserId) {
+        return json(res, { Error: [{ error_description: 'User id mismatch' }] }, 400);
+      }
+      const filters = (req.body as { notification_filters?: Array<{ notification_target?: string }> })
+        ?.notification_filters;
+      const target = filters?.[0]?.notification_target;
+      if (target) {
+        session.webhookTargets.push(target);
+        state.lastWebhookTarget = target;
+      }
+      json(res, { Response: [] });
+    }
+  );
+
+  v1.post(
+    '/user/:userId/monetary-account/:monetaryAccountId/request-inquiry',
+    requireSessionAuth(state),
+    (req, res) => {
+      const session = getSession(req, state);
+      const uid = parseInt(req.params.userId, 10);
+      const monetaryAccountId = parseInt(req.params.monetaryAccountId, 10);
+      if (uid !== session.bunqUserId) {
+        return json(res, { Error: [{ error_description: 'User id mismatch' }] }, 400);
+      }
+      const account = session.monetaryAccounts.find((a) => a.id === monetaryAccountId);
+      if (!account) {
+        return json(res, { Error: [{ error_description: 'Unknown monetary account' }] }, 400);
+      }
+      const id = state.nextInquiryId++;
+      const amountInquired = (req.body as { amount_inquired?: { value?: string; currency?: string } })?.amount_inquired;
+      const description =
+        (req.body as { description?: string })?.description || 'Volleyball payment request';
+      const row: RequestInquiryRow = {
+        id,
+        userId: uid,
+        monetaryAccountId,
+        status: 'PENDING',
+        bunqme_share_url: `https://bunq.me/e2e-mock/${id}`,
+        description,
+      };
+      session.requestInquiries.set(id, row);
+      json(res, {
+        Response: [
+          {
+            RequestInquiry: {
+              id: row.id,
+              created: new Date().toISOString(),
+              updated: new Date().toISOString(),
+              time_responded: null,
+              time_expiry: null,
+              monetary_account_id: monetaryAccountId,
+              amount_inquired: {
+                value: amountInquired?.value ?? '5.00',
+                currency: amountInquired?.currency ?? 'EUR',
+              },
+              amount_responded: { value: '0.00', currency: 'EUR' },
+              status: row.status,
+              description: row.description,
+              user_alias_created: {} as Record<string, unknown>,
+              country: 'NL',
+              counterparty_alias: {} as Record<string, unknown>,
+              type: 'BUNQME',
+              sub_type: 'NONE',
+              bunqme_share_url: row.bunqme_share_url,
+            },
+          },
+        ],
+      });
+    }
+  );
+
+  v1.get(
+    '/user/:userId/monetary-account/:monetaryAccountId/request-inquiry/:inquiryId',
+    requireSessionAuth(state),
+    (req, res) => {
+      const session = getSession(req, state);
+      const uid = parseInt(req.params.userId, 10);
+      const monetaryAccountId = parseInt(req.params.monetaryAccountId, 10);
+      const inquiryId = parseInt(req.params.inquiryId, 10);
+      if (uid !== session.bunqUserId) {
+        return json(res, { Error: [{ error_description: 'User id mismatch' }] }, 400);
+      }
+      const row = session.requestInquiries.get(inquiryId);
+      if (!row || row.monetaryAccountId !== monetaryAccountId) {
+        return json(res, { Error: [{ error_description: 'Request inquiry not found' }] }, 404);
+      }
+      json(res, {
+        Response: [
+          {
+            RequestInquiry: {
+              id: row.id,
+              created: new Date().toISOString(),
+              updated: new Date().toISOString(),
+              time_responded: null,
+              time_expiry: null,
+              monetary_account_id: row.monetaryAccountId,
+              amount_inquired: { value: '5.00', currency: 'EUR' },
+              amount_responded: { value: '0.00', currency: 'EUR' },
+              status: row.status,
+              description: row.description,
+              user_alias_created: {} as Record<string, unknown>,
+              country: 'NL',
+              counterparty_alias: {} as Record<string, unknown>,
+              type: 'BUNQME',
+              sub_type: 'NONE',
+              bunqme_share_url: row.bunqme_share_url,
+            },
+          },
+        ],
+      });
+    }
+  );
+
+  app.use('/v1', v1);
+  return app;
+}

--- a/bunq-mock/src/controlApp.ts
+++ b/bunq-mock/src/controlApp.ts
@@ -1,0 +1,102 @@
+import express from 'express';
+import type { BunqMockState } from './state.js';
+
+const MIN_ACCEPTED_BODY = {
+  NotificationUrl: {
+    target_url: 'http://127.0.0.1:3001/webhooks/bunq',
+    category: 'REQUEST',
+    event_type: 'REQUEST_INQUIRY_ACCEPTED',
+    object: {
+      RequestInquiry: {
+        id: 0 as number,
+        status: 'ACCEPTED',
+        bunqme_share_url: null as string | null,
+      },
+    },
+  },
+};
+
+function controlAuth(expectedToken: string | undefined) {
+  return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (!expectedToken) {
+      return next();
+    }
+    const got = req.headers['x-bunq-mock-control-token'];
+    if (got !== expectedToken) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    next();
+  };
+}
+
+export function createControlApp(state: BunqMockState, options?: { controlToken?: string }): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(controlAuth(options?.controlToken));
+
+  app.post('/reset', (_req, res) => {
+    state.installations.clear();
+    state.sessions.clear();
+    state.lastWebhookTarget = null;
+    state.nextInquiryId = 900_001;
+    res.json({ ok: true });
+  });
+
+  app.post('/webhooks/deliver-request-inquiry-accepted', async (req, res) => {
+    const body = req.body as {
+      requestInquiryId?: string | number;
+      targetUrlOverride?: string;
+    };
+    const id = body.requestInquiryId;
+    if (id === undefined || id === null || id === '') {
+      return res.status(400).json({ error: 'requestInquiryId is required' });
+    }
+    const idNum = typeof id === 'number' ? id : parseInt(String(id), 10);
+    if (Number.isNaN(idNum)) {
+      return res.status(400).json({ error: 'requestInquiryId must be numeric' });
+    }
+
+    const defaultTarget =
+      process.env.BUNQ_MOCK_WEBHOOK_TARGET || 'http://127.0.0.1:3001/webhooks/bunq';
+    const targetUrl = body.targetUrlOverride || state.lastWebhookTarget || defaultTarget;
+
+    const payload = {
+      ...MIN_ACCEPTED_BODY,
+      NotificationUrl: {
+        ...MIN_ACCEPTED_BODY.NotificationUrl,
+        target_url: targetUrl,
+        object: {
+          RequestInquiry: {
+            id: idNum,
+            status: 'ACCEPTED',
+            bunqme_share_url: null,
+          },
+        },
+      },
+    };
+
+    try {
+      const r = await fetch(targetUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const text = await r.text();
+      res.json({
+        ok: r.ok,
+        status: r.status,
+        targetUrl,
+        responseSnippet: text.slice(0, 200),
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error';
+      res.status(502).json({ error: 'Webhook delivery failed', detail: message, targetUrl });
+    }
+  });
+
+  app.get('/health', (_req, res) => {
+    res.json({ ok: true, service: 'bunq-mock-control' });
+  });
+
+  return app;
+}

--- a/bunq-mock/src/controlApp.ts
+++ b/bunq-mock/src/controlApp.ts
@@ -16,6 +16,17 @@ const MIN_ACCEPTED_BODY = {
   },
 };
 
+function markRequestInquiryAcceptedInState(state: BunqMockState, inquiryId: number): boolean {
+  for (const session of state.sessions.values()) {
+    const row = session.requestInquiries.get(inquiryId);
+    if (row) {
+      row.status = 'ACCEPTED';
+      return true;
+    }
+  }
+  return false;
+}
+
 function controlAuth(expectedToken: string | undefined) {
   return (req: express.Request, res: express.Response, next: express.NextFunction) => {
     if (!expectedToken) {
@@ -75,6 +86,8 @@ export function createControlApp(state: BunqMockState, options?: { controlToken?
       },
     };
 
+    markRequestInquiryAcceptedInState(state, idNum);
+
     try {
       const r = await fetch(targetUrl, {
         method: 'POST',
@@ -92,6 +105,17 @@ export function createControlApp(state: BunqMockState, options?: { controlToken?
       const message = e instanceof Error ? e.message : 'Unknown error';
       res.status(502).json({ error: 'Webhook delivery failed', detail: message, targetUrl });
     }
+  });
+
+  app.post('/request-inquiries/:inquiryId/mark-accepted', (req, res) => {
+    const idNum = parseInt(req.params.inquiryId, 10);
+    if (Number.isNaN(idNum)) {
+      return res.status(400).json({ error: 'inquiryId must be numeric' });
+    }
+    if (!markRequestInquiryAcceptedInState(state, idNum)) {
+      return res.status(404).json({ error: 'Request inquiry not found' });
+    }
+    res.json({ ok: true, inquiryId: idNum, status: 'ACCEPTED' });
   });
 
   app.get('/health', (_req, res) => {

--- a/bunq-mock/src/index.ts
+++ b/bunq-mock/src/index.ts
@@ -1,0 +1,20 @@
+import { createInitialState } from './state.js';
+import { createBunqApiApp } from './bunqApiApp.js';
+import { createControlApp } from './controlApp.js';
+
+const API_PORT = parseInt(process.env.BUNQ_MOCK_API_PORT || '3998', 10);
+const CONTROL_PORT = parseInt(process.env.BUNQ_MOCK_CONTROL_PORT || '3999', 10);
+const CONTROL_TOKEN = process.env.BUNQ_MOCK_CONTROL_TOKEN;
+
+const state = createInitialState();
+
+createBunqApiApp(state).listen(API_PORT, () => {
+  console.log(`[bunq-mock] Bunq API simulation listening on http://127.0.0.1:${API_PORT}/v1`);
+});
+
+createControlApp(state, { controlToken: CONTROL_TOKEN }).listen(CONTROL_PORT, () => {
+  console.log(
+    `[bunq-mock] Control API listening on http://127.0.0.1:${CONTROL_PORT}` +
+      (CONTROL_TOKEN ? ' (auth token required)' : ' (no control token set)')
+  );
+});

--- a/bunq-mock/src/state.ts
+++ b/bunq-mock/src/state.ts
@@ -1,0 +1,60 @@
+import { randomBytes } from 'crypto';
+
+export type MonetaryAccountRow = {
+  id: number;
+  description: string;
+  status: string;
+};
+
+export type RequestInquiryRow = {
+  id: number;
+  userId: number;
+  monetaryAccountId: number;
+  status: string;
+  bunqme_share_url: string;
+  description: string;
+};
+
+export type SessionState = {
+  bunqUserId: number;
+  monetaryAccounts: MonetaryAccountRow[];
+  requestInquiries: Map<number, RequestInquiryRow>;
+  webhookTargets: string[];
+};
+
+export type BunqMockState = {
+  installations: Map<string, { deviceRegistered: boolean }>;
+  sessions: Map<string, SessionState>;
+  lastWebhookTarget: string | null;
+  nextInquiryId: number;
+};
+
+export function createInitialState(): BunqMockState {
+  return {
+    installations: new Map(),
+    sessions: new Map(),
+    lastWebhookTarget: null,
+    nextInquiryId: 900_001,
+  };
+}
+
+export function randomInstallationToken(): string {
+  return `inst_${randomBytes(16).toString('hex')}`;
+}
+
+export function randomSessionToken(): string {
+  return `sess_${randomBytes(16).toString('hex')}`;
+}
+
+export function defaultSessionState(): SessionState {
+  const bunqUserId = 1001;
+  const monetaryAccounts: MonetaryAccountRow[] = [
+    { id: 2001, description: 'E2E mock EUR account', status: 'ACTIVE' },
+  ];
+  return {
+    bunqUserId,
+    monetaryAccounts,
+    requestInquiries: new Map(),
+    webhookTargets: [],
+  };
+}

--- a/bunq-mock/tsconfig.json
+++ b/bunq-mock/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -16,7 +16,7 @@ Scope: browser-based tests for the Telegram Mini App running locally in dev mode
   - Toggle `Administrator` only for personas that need global admin rights.
   - Submit `Dev Login`.
 - Use isolated browser contexts for each persona so cookies do not leak between tests.
-- Prefer deterministic setup through backend APIs or database fixtures before each scenario. UI assertions should still cover the browser flow under test.
+- **Implementation rule:** Do not use direct database access or direct HTTP calls (including Playwright `request` fixtures) to perform setup or actions that a real user or administrator could complete through the visible UI. Use the UI instead. Exceptions are allowed only when no UI exists (for example, dev-only login bootstrap or wiping `E2E %` rows between tests in `cleanupE2eData`).
 
 ## Dev login personas
 
@@ -120,12 +120,3 @@ Payment amount display and non-Bunq paid-state UI can be covered only when the s
 - [ ] E2E-STATE-003: Global Admin edits game capacity downward and the UI preserves valid active/waitlist status for existing registrations.
 - [ ] E2E-STATE-004: Browser refresh keeps the authenticated session and current route for each logged-in persona.
 - [ ] E2E-STATE-005: Opening the app in a new browser context without cookies starts unauthenticated.
-
-## Suggested implementation order
-
-1. Dev login helpers and browser-context persona fixtures.
-2. Auth/session smoke tests.
-3. Game creation fixture helpers through UI plus API/database cleanup.
-4. Participant registration flows.
-5. Admin assignment flows.
-6. Negative access-control and API-failure recovery scenarios.

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -121,7 +121,7 @@ Spec: `e2e/game-form.spec.ts`
 - [x] E2E-FORM-007: Global Admin opens `Edit Game Settings` from game details, updates title/location/capacity/deadline/toggles, saves, and sees the updated details.
 - [x] E2E-FORM-008: Global Admin cancels editing and returns to game details without persisting changes.
 - [x] E2E-FORM-009: Required fields and numeric bounds prevent invalid game creation, including missing date, maximum players below minimum, and negative cost.
-- [ ] E2E-FORM-010: On a past game after payment requests were sent, Global Admin still opens **Edit Game Settings**, changes a field such as title, saves, and sees the update on game details (participant roster lock does not block metadata edits).
+- [x] E2E-FORM-010: On a past game after payment requests were sent, Global Admin still opens **Edit Game Settings**, changes a field such as title, saves, and sees the update on game details (participant roster lock does not block metadata edits).
 
 ## Game administration scenarios
 
@@ -137,10 +137,10 @@ Spec: `e2e/game-administration.spec.ts`
 - [x] E2E-ADMIN-008: Non-admin Participant A cannot reach create/edit/admin-only screens by direct URL and is redirected or blocked.
 - [x] E2E-ADMIN-009: Assigned Admin receives a 403 error when creating a game on a weekday outside their assignment.
 - [x] E2E-ADMIN-010: Assigned Admin receives a 403 error when saving edits to a game outside their assignment.
-- [ ] E2E-ADMIN-011: On a past paid game (Bunq enabled, Participant A registered): Global Admin adds Participant B via **Add Participant** before payment requests; sends payment requests; **Add Participant** is then unavailable while B remains on the roster.
-- [ ] E2E-ADMIN-012: On a past or readonly game: Global Admin removes a player before payment requests; after sending payment requests, **Remove player** is unavailable and active rows show **Paid** / **Unpaid** controls instead.
-- [ ] E2E-ADMIN-013: Global Admin opens player info for a user with outstanding payment requests, sees `Unpaid games` listing the game, and **Send payment reminder** completes with UI success feedback (do not assert SMS/Telegram delivery).
-- [ ] E2E-ADMIN-014: On a readonly past game with cost (Bunq enabled): before payment requests, **Add guest** with `Invited by` / inviter search adds a guest; after payment requests are sent, inviter search is absent and **Add guest** cannot add new entries (readonly or registration-closed error in the dialog).
+- [x] E2E-ADMIN-011: On a past paid game (Bunq enabled, Participant A registered): Global Admin adds Participant B via **Add Participant** before payment requests; sends payment requests; **Add Participant** is then unavailable while B remains on the roster.
+- [x] E2E-ADMIN-012: On a past or readonly game: Global Admin removes a player before payment requests; after sending payment requests, **Remove player** is unavailable and active rows show **Paid** / **Unpaid** controls instead.
+- [x] E2E-ADMIN-013: Global Admin opens player info for a user with outstanding payment requests, sees `Unpaid games` listing the game, and **Send payment reminder** completes with UI success feedback (do not assert SMS/Telegram delivery).
+- [x] E2E-ADMIN-014: On a readonly past game with cost (Bunq enabled): before payment requests, **Add guest** with `Invited by` / inviter search adds a guest; after payment requests are sent, inviter search is absent and **Add guest** cannot add new entries (readonly or registration-closed error in the dialog).
 
 ## Game administrator assignment scenarios
 

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -23,10 +23,9 @@ Scope: browser-based tests for the Telegram Mini App running locally in dev mode
 Use unique phone numbers per test run when tests create mutable state.
 
 - Participant A: non-admin user for normal registration and profile flows.
-- Participant B: non-admin user for capacity, waitlist, priority-player, and multi-user scenarios.
+- Participant B: non-admin user for capacity, waitlist, and multi-user scenarios.
 - Global Admin: dev login with `Administrator` checked.
 - Assigned Admin: non-admin user who becomes a game administrator through an assignment created by Global Admin.
-- Priority Player: non-admin user added to an assignment's priority-player list.
 
 ## Out of scope for this checklist
 
@@ -87,12 +86,11 @@ Payment amount display and non-Bunq paid-state UI can be covered only when the s
 - [ ] E2E-FORM-002: Global Admin creates a standard game with date/time, maximum players, unregister deadline, per-participant cost, location name, optional location link, and optional title.
 - [ ] E2E-FORM-003: Global Admin creates a game with total-cost pricing and sees the per-participant preview update as maximum players changes.
 - [ ] E2E-FORM-004: Global Admin creates a game with `Playing 5-1` enabled and verifies it appears in the appropriate games list/category behavior.
-- [ ] E2E-FORM-005: Global Admin creates a game with `With priority players` enabled for a day/type that has priority players configured.
-- [ ] E2E-FORM-006: Global Admin creates a readonly game and verifies regular participants cannot self-register.
-- [ ] E2E-FORM-007: Global Admin cancels game creation and returns without creating a game.
-- [ ] E2E-FORM-008: Global Admin opens `Edit Game Settings` from game details, updates title/location/capacity/deadline/toggles, saves, and sees the updated details.
-- [ ] E2E-FORM-009: Global Admin cancels editing and returns to game details without persisting changes.
-- [ ] E2E-FORM-010: Required fields and numeric bounds prevent invalid game creation, including missing date, maximum players below minimum, and negative cost.
+- [ ] E2E-FORM-005: Global Admin creates a readonly game and verifies regular participants cannot self-register.
+- [ ] E2E-FORM-006: Global Admin cancels game creation and returns without creating a game.
+- [ ] E2E-FORM-007: Global Admin opens `Edit Game Settings` from game details, updates title/location/capacity/deadline/toggles, saves, and sees the updated details.
+- [ ] E2E-FORM-008: Global Admin cancels editing and returns to game details without persisting changes.
+- [ ] E2E-FORM-009: Required fields and numeric bounds prevent invalid game creation, including missing date, maximum players below minimum, and negative cost.
 
 ## Game administration scenarios
 
@@ -116,34 +114,13 @@ Payment amount display and non-Bunq paid-state UI can be covered only when the s
 - [ ] E2E-ASSIGN-006: Global Admin cancels assignment deletion and the assignment remains.
 - [ ] E2E-ASSIGN-007: Non-admin Participant A is redirected away from `/game-administrators`.
 
-## Priority player scenarios
-
-- [ ] E2E-PRIORITY-001: Global Admin opens `Manage Priority Players` for an administrator assignment.
-- [ ] E2E-PRIORITY-002: Global Admin sees the `No priority players yet.` empty state before adding players.
-- [ ] E2E-PRIORITY-003: Global Admin adds Priority Player through `Search users to add...` and sees the user in the priority-player list.
-- [ ] E2E-PRIORITY-004: Global Admin opens player info from a priority-player row.
-- [ ] E2E-PRIORITY-005: Global Admin deletes a priority-player assignment after confirming the browser prompt.
-- [ ] E2E-PRIORITY-006: Global Admin cancels priority-player deletion and the assignment remains.
-- [ ] E2E-PRIORITY-007: Assigned Admin can manage priority players only for their own game administrator assignment.
-- [ ] E2E-PRIORITY-008: Participant A cannot manage another user's priority-player assignment and is redirected to the allowed page.
-- [ ] E2E-PRIORITY-009: Invalid priority-player assignment ids redirect back to `Game Administrators`.
-
 ## Cross-user and state-transition scenarios
 
 - [ ] E2E-STATE-001: Global Admin creates a game, Participant A joins it in a separate context, and Global Admin sees Participant A in the players list after refresh.
 - [ ] E2E-STATE-002: Participant A and Participant B compete for the last available spot; one becomes active and the other becomes waitlisted deterministically.
 - [ ] E2E-STATE-003: Global Admin edits game capacity downward and the UI preserves valid active/waitlist status for existing registrations.
-- [ ] E2E-STATE-004: Priority Player receives priority behavior for a priority-enabled game while a non-priority participant follows the normal registration order.
-- [ ] E2E-STATE-005: Browser refresh keeps the authenticated session and current route for each logged-in persona.
-- [ ] E2E-STATE-006: Opening the app in a new browser context without cookies starts unauthenticated.
-
-## Accessibility and browser-mode smoke scenarios
-
-- [ ] E2E-A11Y-001: Core unauthenticated, games home, game details, create game, and admin pages expose exactly one main landmark.
-- [ ] E2E-A11Y-002: Primary form controls have accessible labels matching visible labels.
-- [ ] E2E-A11Y-003: Keyboard-only user can log in, open filters, create a game, and submit/cancel dialogs.
-- [ ] E2E-A11Y-004: Browser-mode brand link `Haarlem Volley Bot` returns to the games home from nested routes.
-- [ ] E2E-A11Y-005: Modal dialogs keep actionable controls reachable by keyboard and close through cancel/escape paths where supported.
+- [ ] E2E-STATE-004: Browser refresh keeps the authenticated session and current route for each logged-in persona.
+- [ ] E2E-STATE-005: Opening the app in a new browser context without cookies starts unauthenticated.
 
 ## Suggested implementation order
 
@@ -151,6 +128,5 @@ Payment amount display and non-Bunq paid-state UI can be covered only when the s
 2. Auth/session smoke tests.
 3. Game creation fixture helpers through UI plus API/database cleanup.
 4. Participant registration flows.
-5. Admin assignment and priority-player flows.
+5. Admin assignment flows.
 6. Negative access-control and API-failure recovery scenarios.
-7. Accessibility smoke coverage.

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -43,8 +43,8 @@ Payment amount display and non-Bunq paid-state UI can be covered only when the s
 
 ## Authentication and session scenarios
 
-- [ ] E2E-AUTH-001: Unauthenticated visitor sees the landing page with `Welcome`, `Telegram`, `Phone number`, `How it works`, and the GitHub source link.
-- [ ] E2E-AUTH-002: Visitor expands `How it works` and sees the community, registration, notification, and cost-sharing explanation.
+- [ ] E2E-AUTH-001: Unauthenticated visitor sees the landing page with `Welcome`, `Telegram`, `Phone number`, and `How it works`.
+- [ ] E2E-AUTH-002: Visitor expands `How it works` and sees the community, registration, notification, cost-sharing explanation, and GitHub source link.
 - [ ] E2E-AUTH-003: Participant A logs in through dev mode with phone number and display name, then lands on the authenticated games home.
 - [ ] E2E-AUTH-004: Global Admin logs in through dev mode with the `Administrator` checkbox selected and sees admin controls on the games home.
 - [ ] E2E-AUTH-005: Two isolated Playwright browser contexts can log in as different users and keep separate displayed names and sessions.

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -98,11 +98,10 @@ Payment amount display and non-Bunq paid-state UI can be covered only when the s
 - [ ] E2E-ADMIN-002: Global Admin cancels the delete confirmation and the game remains available.
 - [ ] E2E-ADMIN-003: Global Admin adds an existing user to a readonly or past game through the `Search users to add...` admin flow.
 - [ ] E2E-ADMIN-004: Global Admin removes a player from a game and the players list updates.
-- [ ] E2E-ADMIN-005: Global Admin removes a waitlisted player and the waiting list updates.
-- [ ] E2E-ADMIN-006: Global Admin opens player info from a player row and sees the selected user's public information.
-- [ ] E2E-ADMIN-007: Assigned Admin can manage games for their assigned day/type, including creating a game and reaching permitted admin actions.
-- [ ] E2E-ADMIN-008: Assigned Admin cannot access global-only routes such as game administrator assignment management.
-- [ ] E2E-ADMIN-009: Non-admin Participant A cannot reach create/edit/admin-only screens by direct URL and is redirected or blocked.
+- [ ] E2E-ADMIN-005: Global Admin opens player info from a player row and sees the selected user's public information.
+- [ ] E2E-ADMIN-006: Assigned Admin can manage games for their assigned day/type, including creating a game and reaching permitted admin actions.
+- [ ] E2E-ADMIN-007: Assigned Admin cannot access global-only routes such as game administrator assignment management.
+- [ ] E2E-ADMIN-008: Non-admin Participant A cannot reach create/edit/admin-only screens by direct URL and is redirected or blocked.
 
 ## Game administrator assignment scenarios
 

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -70,7 +70,7 @@ Spec: `e2e/games-home.spec.ts`
 - [x] E2E-HOME-012: Home error state shows `Error` and `Retry` when the games API fails, then recovers after retry.
 - [x] E2E-HOME-013: With default category filter (Sunday), participant sees `No games available` when the only upcoming game is a Thursday 5-1 game.
 - [x] E2E-HOME-014: Participant deselects all category options in the multi-select and sees `No games available` even when games exist for other categories.
-- [ ] E2E-HOME-015: Participant A with an unpaid past game (after admin sent payment requests) sees `Your unpaid games` on the upcoming home view, opens the entry, and **Pay now** opens the Bunq payment link in a new browser tab (or window).
+- [x] E2E-HOME-015: Participant A with an unpaid past game (after admin sent payment requests) sees `Your unpaid games` on the upcoming home view, opens the entry, and **Pay now** opens the Bunq payment link in a new browser tab (or window).
 
 ## Game details participant scenarios
 
@@ -203,13 +203,15 @@ Past or readonly games with `paymentAmount > 0`, Bunq enabled for the collecting
 - [x] E2E-BUNQ-PAY-007: Game with zero cost does not show send-payment-requests even when past and Bunq is enabled.
 - [x] E2E-BUNQ-PAY-008: Past game already marked fully paid on the games home does not show send-payment-requests on game details (`fully_paid` set via allowed DB helper in test).
 
-## Bunq payment status scenarios (planned)
+## Bunq payment status scenarios
+
+Spec: `e2e/bunq-status.spec.ts`
 
 Status surfaces: per-player `Paid` / `Unpaid` on game details (past/readonly, after requests sent), **Check payment status for this game** sync button on game details, paid/total counters on past game cards, and `Show fully paid games` on the past filter. Optional bulk route: `/check-payments` (password dialog on load; no in-app nav link today—use only if testing that screen explicitly).
 
-- [ ] E2E-BUNQ-STATUS-002: Global Admin clicks **Check payment status for this game**, enters the Bunq password, sees `Payment check completed`, and unpaid players update to `Paid` when the mock reports inquiry status `ACCEPTED`.
-- [ ] E2E-BUNQ-STATUS-003: Global Admin toggles a player from `Unpaid` to `Paid` and back via the paid-status control on the player row; counts on the games home past list update after refresh.
-- [ ] E2E-BUNQ-STATUS-004: When all active players are paid, the past game card shows matching paid/total counts (e.g. `2/2`); with `Show fully paid games` unchecked, the game is hidden from the past list until the toggle is enabled (extends HOME-009 with Bunq-driven fully-paid state via UI).
-- [ ] E2E-BUNQ-STATUS-005: Wrong password on per-game check keeps the password dialog open with `Invalid password`.
-- [ ] E2E-BUNQ-STATUS-006: Global Admin opens `/check-payments`, submits password on `Enter Bunq API Password`, sees completion feedback, and returns to games home; past unpaid games reflect updated statuses where the mock reports payment accepted.
-- [ ] E2E-BUNQ-STATUS-007: Participant A on a past game they joined does not see admin paid-status toggles or check-payment/sync controls; they may still see price and their own registration state.
+- [x] E2E-BUNQ-STATUS-002: Global Admin clicks **Check payment status for this game**, enters the Bunq password, sees `Payment check completed`, and unpaid players update to `Paid` when the mock reports inquiry status `ACCEPTED`.
+- [x] E2E-BUNQ-STATUS-003: Global Admin toggles a player from `Unpaid` to `Paid` and back via the paid-status control on the player row; counts on the games home past list update after refresh.
+- [x] E2E-BUNQ-STATUS-004: When all active players are paid, the past game card shows matching paid/total counts (e.g. `2/2`); with `Show fully paid games` unchecked, the game is hidden from the past list until the toggle is enabled (extends HOME-009 with Bunq-driven fully-paid state via UI).
+- [x] E2E-BUNQ-STATUS-005: Wrong password on per-game check keeps the password dialog open with `Invalid password`.
+- [x] E2E-BUNQ-STATUS-006: Global Admin opens `/check-payments`, submits password on `Enter Bunq API Password`, sees completion feedback, and returns to games home; past unpaid games reflect updated statuses where the mock reports payment accepted.
+- [x] E2E-BUNQ-STATUS-007: Participant A on a past game they joined does not see admin paid-status toggles or check-payment/sync controls; they may still see price and their own registration state.

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -1,13 +1,15 @@
 # Playwright E2E Scenario Checklist
 
-Purpose: define the first automated end-to-end scenario set for the application using Playwright.
+Purpose: define the automated end-to-end scenario set for the application using Playwright.
 
-Scope: browser-based tests for the Telegram Mini App running locally in dev mode. Bunq integration features are intentionally excluded for now.
+Scope: browser-based tests for the Telegram Mini App running locally in dev mode, including Bunq payment integration (configuration, payment requests, and payment status tracking for past games).
 
 ## Test environment assumptions
 
-- Run the app with dev mode enabled, for example `DEV_MODE=true npm run dev` or `npm run dev:local`.
+- Run the app with dev mode enabled, for example `DEV_MODE=true npm run dev` or `npm run dev:local`, or the Playwright stack via `scripts/playwright-dev-server.sh` (starts backend, mini app, and `bunq-mock`).
 - Target the frontend at `http://127.0.0.1:3001`; the Vite proxy forwards `/api` requests to the backend.
+- For Bunq scenarios, point the backend at the local mock: `BUNQ_API_URL=http://127.0.0.1:3998/v1` (default in the Playwright dev server script). Reset mock state between tests with the bunq-mock control `POST /reset` (see `e2e/support/fixtures.ts` `resetBunqMock`).
+- Use a fixed Bunq encryption password in tests (for example `BunqE2E!Pass9`) and a mock API key such as `e2e-bunq-api-key` with API key name `E2E Bunq Client`.
 - Use the visible dev-mode phone login flow instead of Telegram auth:
   - Open the landing page.
   - Choose `Phone number`.
@@ -16,7 +18,9 @@ Scope: browser-based tests for the Telegram Mini App running locally in dev mode
   - Toggle `Administrator` only for personas that need global admin rights.
   - Submit `Dev Login`.
 - Use isolated browser contexts for each persona so cookies do not leak between tests.
-- **Implementation rule:** Do not use direct database access or direct HTTP calls (including Playwright `request` fixtures) to perform setup or actions that a real user or administrator could complete through the visible UI. Use the UI instead. Exceptions are allowed only when no UI exists (for example, dev-only login bootstrap or wiping `E2E %` rows between tests in `cleanupE2eData`).
+- **Implementation rule:** Do not use direct database access or direct HTTP calls to the **application** (including Playwright `request` fixtures against `/api`) to perform setup or actions that a real user or administrator could complete through the visible UI. Use the UI instead. Exceptions are allowed only when no in-app UI exists:
+  - dev-only login bootstrap or wiping `E2E %` rows between tests in `cleanupE2eData`;
+  - **bunq-mock control plane** (`http://127.0.0.1:3999`) to reset mock state or deliver external Bunq webhooks (simulates Bunq notifying the app; there is no mini-app screen for this).
 
 ## Dev login personas
 
@@ -29,16 +33,9 @@ Use unique phone numbers per test run when tests create mutable state.
 
 ## Out of scope for this checklist
 
-Do not automate these scenarios yet:
-
-- `/bunq-settings`
-- `/bunq-settings/user/:assignedUserId`
-- `/check-payments`
-- Game details actions that send payment requests.
-- Game details actions that check payment status through Bunq.
-- Bunq credential setup, Bunq password dialogs, or Bunq-backed payment reconciliation.
-
-Payment amount display and non-Bunq paid-state UI can be covered only when the scenario does not depend on Bunq APIs.
+- Real Bunq production or sandbox credentials; all payment flows use `bunq-mock`.
+- Telegram-native auth flows (tests use dev phone login).
+- SMS/Telegram delivery of payment request links to participants (outbound messaging is not exercised in the browser).
 
 ## Authentication and session scenarios
 
@@ -120,3 +117,44 @@ Payment amount display and non-Bunq paid-state UI can be covered only when the s
 - [ ] E2E-STATE-003: Global Admin edits game capacity downward and the UI preserves valid active/waitlist status for existing registrations.
 - [ ] E2E-STATE-004: Browser refresh keeps the authenticated session and current route for each logged-in persona.
 - [ ] E2E-STATE-005: Opening the app in a new browser context without cookies starts unauthenticated.
+
+## Bunq integration configuration scenarios
+
+Routes: `/bunq-settings` (global admin’s own credentials), `/bunq-settings/user/:assignedUserId` (global admin configuring an assigned game administrator’s credentials). Entry points: games home **Bunq Settings** cog (`title="Bunq Settings"`), or **Configure Bunq Settings** on a row in `Game Administrators`.
+
+- [ ] E2E-BUNQ-CONFIG-001: Global Admin opens Bunq Settings from the games home and sees `Bunq Settings`, loading complete, and status text `Bunq integration is disabled`.
+- [ ] E2E-BUNQ-CONFIG-002: Global Admin clicks `Enable Bunq Integration`, sees `Specify Bunq API Credentials` with API Key, API Key Name, and Password fields, and cannot submit until all three are filled.
+- [ ] E2E-BUNQ-CONFIG-003: Global Admin submits valid mock credentials (`Enable Integration`) and sees `Bunq integration enabled successfully` and status `Bunq integration is enabled`.
+- [ ] E2E-BUNQ-CONFIG-004: With integration enabled, Global Admin uses `Choose account to receive payments to`, enters the Bunq password, clicks `Load Accounts`, selects a monetary account from `Choose account to receive payments to`, and sees `Bunq account updated successfully!` (or equivalent success feedback).
+- [ ] E2E-BUNQ-CONFIG-005: Global Admin clicks `Install Webhook`, enters the Bunq password in `Install Bunq Webhook`, submits, and sees success feedback without leaving the settings page.
+- [ ] E2E-BUNQ-CONFIG-006: Global Admin opens `Update API Key`, cancels via `Cancel`, and returns to the enabled settings view without changing status.
+- [ ] E2E-BUNQ-CONFIG-007: Global Admin disables integration: `Disable Integration` → confirm browser/Telegram prompt → `Bunq integration disabled successfully` and status returns to disabled.
+- [ ] E2E-BUNQ-CONFIG-008: Global Admin cancels disable at the confirmation prompt and integration remains enabled.
+- [ ] E2E-BUNQ-CONFIG-009: Global Admin opens `Game Administrators`, uses **Configure Bunq Settings** for Assigned Admin, sees `Bunq Settings (<display name>)`, and completes enable flow for that user (same credential form as own settings).
+- [ ] E2E-BUNQ-CONFIG-010: Participant A navigates to `/bunq-settings` and is redirected away or blocked from managing Bunq credentials.
+- [ ] E2E-BUNQ-CONFIG-011: Wrong Bunq password on enable or webhook install shows an inline error and keeps the user on the relevant form/dialog.
+
+## Bunq payment request scenarios
+
+Past or readonly games with `paymentAmount > 0`, Bunq enabled for the collecting admin, and no `fullyPaid` flag show **Send payment requests** (`title="Send payment requests to unpaid players"`). Prepare games via UI: create with cost, register players, then move date to the past through **Edit Game Settings** (do not set dates via DB).
+
+- [ ] E2E-BUNQ-PAY-001: Global Admin with Bunq enabled opens a past paid game and sees the send-payment-requests control; an upcoming game with the same cost does not show it.
+- [ ] E2E-BUNQ-PAY-002: Global Admin sends payment requests: click send → password dialog `Please enter your password to send payment requests.` → submit → popup `Payment requests sent` with a success count → dismiss → page shows `Payments collected by` with the admin’s display name.
+- [ ] E2E-BUNQ-PAY-003: After payment requests are sent, active players show `Unpaid` (or `Paid` if already settled); admin remove-player control is no longer available for those rows.
+- [ ] E2E-BUNQ-PAY-004: Invalid Bunq password on send keeps the password dialog open with `Invalid password` and does not show the success popup.
+- [ ] E2E-BUNQ-PAY-005: Assigned Admin with their own Bunq configured (via CONFIG-009) can send payment requests on a past game they administer; Participant A does not see send-payment controls on the same game.
+- [ ] E2E-BUNQ-PAY-006: Readonly past game with cost and registrations follows the same send-payment-requests flow as a normal past game.
+- [ ] E2E-BUNQ-PAY-007: Game with zero cost does not show send-payment-requests even when past and Bunq is enabled.
+- [ ] E2E-BUNQ-PAY-008: Past game already marked fully paid on the games home does not show send-payment-requests on game details.
+
+## Bunq payment status scenarios (past games)
+
+Status surfaces: per-player `Paid` / `Unpaid` on game details (past/readonly, after requests sent), **Check payment status for this game** sync button on game details, paid/total counters on past game cards, and `Show fully paid games` on the past filter. Optional bulk route: `/check-payments` (password dialog on load; no in-app nav link today—use only if testing that screen explicitly).
+
+- [ ] E2E-BUNQ-STATUS-001: After admin sends payment requests, bunq-mock delivers `REQUEST_INQUIRY_ACCEPTED` for the participant’s inquiry (control plane); reload game details and the player row shows `Paid`. *(Implemented as `E2E-BUNQ-001` in `e2e/bunq-webhook.spec.ts`.)*
+- [ ] E2E-BUNQ-STATUS-002: Global Admin clicks **Check payment status for this game**, enters the Bunq password, sees `Payment check completed`, and unpaid players update to `Paid` when the mock reports inquiry status `ACCEPTED` (webhook delivery or future mock status helper—do not assert via DB).
+- [ ] E2E-BUNQ-STATUS-003: Global Admin toggles a player from `Unpaid` to `Paid` and back via the paid-status control on the player row; counts on the games home past list update after refresh.
+- [ ] E2E-BUNQ-STATUS-004: When all active players are paid, the past game card shows matching paid/total counts (e.g. `2/2`); with `Show fully paid games` unchecked, the game is hidden from the past list until the toggle is enabled (extends HOME-009 with Bunq-driven fully-paid state via UI, not `updateGame` for `fully_paid`).
+- [ ] E2E-BUNQ-STATUS-005: Wrong password on per-game check keeps the password dialog open with `Invalid password`.
+- [ ] E2E-BUNQ-STATUS-006: Global Admin opens `/check-payments`, submits password on `Enter Bunq API Password`, sees completion feedback, and returns to games home; past unpaid games reflect updated statuses where the mock reports payment accepted.
+- [ ] E2E-BUNQ-STATUS-007: Participant A on a past game they joined does not see admin paid-status toggles or check-payment/sync controls; they may still see price and their own registration state.

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -170,21 +170,23 @@ Spec: `e2e/bunq-webhook.spec.ts`
 
 - [x] E2E-BUNQ-001: Admin enables Bunq via settings UI, moves game to the past, sends payment requests; bunq-mock delivers `REQUEST_INQUIRY_ACCEPTED` for the participant's inquiry (control plane); after reload the player row shows `Paid`.
 
-## Bunq integration configuration scenarios (planned)
+## Bunq integration configuration scenarios
+
+Spec: `e2e/bunq-config.spec.ts`
 
 Routes: `/bunq-settings` (global admin’s own credentials), `/bunq-settings/user/:assignedUserId` (global admin configuring an assigned game administrator’s credentials). Entry points: games home **Bunq Settings** cog (`title="Bunq Settings"`), or **Configure Bunq Settings** on a row in `Game Administrators`.
 
-- [ ] E2E-BUNQ-CONFIG-001: Global Admin opens Bunq Settings from the games home and sees `Bunq Settings`, loading complete, and status text `Bunq integration is disabled`.
-- [ ] E2E-BUNQ-CONFIG-002: Global Admin clicks `Enable Bunq Integration`, sees `Specify Bunq API Credentials` with API Key, API Key Name, and Password fields, and cannot submit until all three are filled.
-- [ ] E2E-BUNQ-CONFIG-003: Global Admin submits valid mock credentials (`Enable Integration`) and sees `Bunq integration enabled successfully` and status `Bunq integration is enabled`.
-- [ ] E2E-BUNQ-CONFIG-004: With integration enabled, Global Admin uses `Choose account to receive payments to`, enters the Bunq password, clicks `Load Accounts`, selects a monetary account, and sees success feedback.
-- [ ] E2E-BUNQ-CONFIG-005: Global Admin clicks `Install Webhook`, enters the Bunq password in `Install Bunq Webhook`, submits, and sees success feedback without leaving the settings page.
-- [ ] E2E-BUNQ-CONFIG-006: Global Admin opens `Update API Key`, cancels via `Cancel`, and returns to the enabled settings view without changing status.
-- [ ] E2E-BUNQ-CONFIG-007: Global Admin disables integration: `Disable Integration` → confirm prompt → `Bunq integration disabled successfully` and status returns to disabled.
-- [ ] E2E-BUNQ-CONFIG-008: Global Admin cancels disable at the confirmation prompt and integration remains enabled.
-- [ ] E2E-BUNQ-CONFIG-009: Global Admin opens `Game Administrators`, uses **Configure Bunq Settings** for Assigned Admin, sees `Bunq Settings (<display name>)`, and completes enable flow for that user.
-- [ ] E2E-BUNQ-CONFIG-010: Participant A navigates to `/bunq-settings` and is redirected away or blocked from managing Bunq credentials.
-- [ ] E2E-BUNQ-CONFIG-011: Wrong Bunq password on enable or webhook install shows an inline error and keeps the user on the relevant form/dialog.
+- [x] E2E-BUNQ-CONFIG-001: Global Admin opens Bunq Settings from the games home and sees `Bunq Settings`, loading complete, and status text `Bunq integration is disabled`.
+- [x] E2E-BUNQ-CONFIG-002: Global Admin clicks `Enable Bunq Integration`, sees `Specify Bunq API Credentials` with API Key, API Key Name, and Password fields, and cannot submit until all three are filled.
+- [x] E2E-BUNQ-CONFIG-003: Global Admin submits valid mock credentials (`Enable Integration`) and sees `Bunq integration enabled successfully` and status `Bunq integration is enabled`.
+- [x] E2E-BUNQ-CONFIG-004: With integration enabled, Global Admin uses `Choose account to receive payments to`, enters the Bunq password, clicks `Load Accounts`, selects a monetary account, and sees success feedback.
+- [x] E2E-BUNQ-CONFIG-005: Global Admin clicks `Install Webhook`, enters the Bunq password in `Install Bunq Webhook`, submits, and sees success feedback without leaving the settings page.
+- [x] E2E-BUNQ-CONFIG-006: Global Admin opens `Update API Key`, cancels via `Cancel`, and returns to the enabled settings view without changing status.
+- [x] E2E-BUNQ-CONFIG-007: Global Admin disables integration: `Disable Integration` → confirm prompt → `Bunq integration disabled successfully` and status returns to disabled.
+- [x] E2E-BUNQ-CONFIG-008: Global Admin cancels disable at the confirmation prompt and integration remains enabled.
+- [x] E2E-BUNQ-CONFIG-009: Global Admin opens `Game Administrators`, uses **Configure Bunq Settings** for Assigned Admin, sees `Bunq Settings (<display name>)`, and completes enable flow for that user.
+- [x] E2E-BUNQ-CONFIG-010: Participant A navigates to `/bunq-settings` and is redirected away or blocked from managing Bunq credentials.
+- [x] E2E-BUNQ-CONFIG-011: Wrong Bunq password on monetary account load or webhook install shows an inline error and keeps the user on the relevant form/dialog.
 
 ## Bunq payment request scenarios (planned)
 

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -188,18 +188,20 @@ Routes: `/bunq-settings` (global admin’s own credentials), `/bunq-settings/use
 - [x] E2E-BUNQ-CONFIG-010: Participant A navigates to `/bunq-settings` and is redirected away or blocked from managing Bunq credentials.
 - [x] E2E-BUNQ-CONFIG-011: Wrong Bunq password on monetary account load or webhook install shows an inline error and keeps the user on the relevant form/dialog.
 
-## Bunq payment request scenarios (planned)
+## Bunq payment request scenarios
+
+Spec: `e2e/bunq-pay.spec.ts`
 
 Past or readonly games with `paymentAmount > 0`, Bunq enabled for the collecting admin, and no `fullyPaid` flag show **Send payment requests** (`title="Send payment requests to unpaid players"`). Prepare games via UI: create with cost, register players, then move date to the past through **Edit Game Settings** (do not set dates via DB).
 
-- [ ] E2E-BUNQ-PAY-001: Global Admin with Bunq enabled opens a past paid game and sees the send-payment-requests control; an upcoming game with the same cost does not show it.
-- [ ] E2E-BUNQ-PAY-002: Global Admin sends payment requests: password dialog → popup `Payment requests sent` → `Payments collected by` with admin display name, active players show `Unpaid` (or `Paid` if settled), and roster add/remove controls are locked as in E2E-ADMIN-011 and E2E-ADMIN-012.
-- [ ] E2E-BUNQ-PAY-003: After payment requests were sent for all unpaid active players, **Send payment requests** is hidden or a second send via UI reports zero new requests created.
-- [ ] E2E-BUNQ-PAY-004: Invalid Bunq password on send keeps the password dialog open with `Invalid password` and does not show the success popup.
-- [ ] E2E-BUNQ-PAY-005: Assigned Admin with their own Bunq configured (via CONFIG-009) can send payment requests on a past game they administer; Participant A does not see send-payment controls on the same game.
-- [ ] E2E-BUNQ-PAY-006: Readonly past game with cost and registrations follows the same send-payment-requests flow as a normal past game.
-- [ ] E2E-BUNQ-PAY-007: Game with zero cost does not show send-payment-requests even when past and Bunq is enabled.
-- [ ] E2E-BUNQ-PAY-008: Past game already marked fully paid on the games home does not show send-payment-requests on game details.
+- [x] E2E-BUNQ-PAY-001: Global Admin with Bunq enabled opens a past paid game and sees the send-payment-requests control; an upcoming game with the same cost does not show it.
+- [x] E2E-BUNQ-PAY-002: Global Admin sends payment requests: password dialog → popup `Payment requests sent` → `Payments collected by` with admin display name, active players show `Unpaid` (or `Paid` if settled), and roster add/remove controls are locked as in E2E-ADMIN-011 and E2E-ADMIN-012.
+- [x] E2E-BUNQ-PAY-003: After payment requests were sent for all unpaid active players, **Send payment requests** is hidden or a second send via UI reports zero new requests created.
+- [x] E2E-BUNQ-PAY-004: Invalid Bunq password on send keeps the password dialog open with `Invalid password` and does not show the success popup.
+- [x] E2E-BUNQ-PAY-005: Assigned Admin with their own Bunq configured (via CONFIG-009) can send payment requests on a past game they administer; Participant A does not see send-payment controls on the same game.
+- [x] E2E-BUNQ-PAY-006: Readonly past game with cost and registrations follows the same send-payment-requests flow as a normal past game.
+- [x] E2E-BUNQ-PAY-007: Game with zero cost does not show send-payment-requests even when past and Bunq is enabled.
+- [x] E2E-BUNQ-PAY-008: Past game already marked fully paid on the games home does not show send-payment-requests on game details (`fully_paid` set via allowed DB helper in test).
 
 ## Bunq payment status scenarios (planned)
 

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -62,6 +62,7 @@ Use unique phone numbers per test run when tests create mutable state.
 - [ ] E2E-HOME-010: Global Admin sees `Game Administrators` and `Create New Game` controls for non-integration admin access.
 - [ ] E2E-HOME-011: Assigned Admin sees `Create New Game` access without global-only administration links.
 - [ ] E2E-HOME-012: Home error state shows `Error` and `Retry` when the games API fails, then recovers after retry.
+- [ ] E2E-HOME-013: Participant A with an unpaid past game (after admin sent payment requests) sees `Your unpaid games` on the upcoming home view, opens the entry, and **Pay now** opens the Bunq payment link in a new browser tab (or window).
 
 ## Game details participant scenarios
 
@@ -88,19 +89,19 @@ Use unique phone numbers per test run when tests create mutable state.
 - [ ] E2E-FORM-007: Global Admin opens `Edit Game Settings` from game details, updates title/location/capacity/deadline/toggles, saves, and sees the updated details.
 - [ ] E2E-FORM-008: Global Admin cancels editing and returns to game details without persisting changes.
 - [ ] E2E-FORM-009: Required fields and numeric bounds prevent invalid game creation, including missing date, maximum players below minimum, and negative cost.
+- [ ] E2E-FORM-010: On a past game after payment requests were sent, Global Admin still opens **Edit Game Settings**, changes a field such as title, saves, and sees the update on game details (participant roster lock does not block metadata edits).
 
 ## Game administration scenarios
 
-Participant add/remove on past or readonly games applies only **before** payment requests have been sent (`collectorUser` unset). After requests are sent, use the roster-lock scenarios in the next section instead.
-
 - [ ] E2E-ADMIN-001: Global Admin deletes an upcoming game from game details after confirming the browser prompt.
 - [ ] E2E-ADMIN-002: Global Admin cancels the delete confirmation and the game remains available.
-- [ ] E2E-ADMIN-003: Global Admin adds an existing user to a readonly or past game through the `Search users to add...` admin flow while payment requests have **not** yet been sent.
-- [ ] E2E-ADMIN-004: Global Admin removes a player from a past or readonly game and the players list updates while payment requests have **not** yet been sent.
-- [ ] E2E-ADMIN-005: Global Admin opens player info from a player row and sees the selected user's public information.
+- [ ] E2E-ADMIN-003: On a past paid game (Bunq enabled, Participant A registered): Global Admin adds Participant B via **Add Participant** and `Search users to add...` before payment requests; sends payment requests; **Add Participant** is then unavailable while B remains on the roster.
+- [ ] E2E-ADMIN-004: On a past or readonly game: Global Admin removes a player before payment requests; after sending payment requests, **Remove player** is unavailable and active rows show **Paid** / **Unpaid** controls instead.
+- [ ] E2E-ADMIN-005: Global Admin opens player info from a player row and sees public information; for a user with outstanding payment requests, also sees `Unpaid games` listing the game and **Send payment reminder** completes with UI success feedback (do not assert SMS/Telegram delivery).
 - [ ] E2E-ADMIN-006: Assigned Admin can manage games for their assigned day/type, including creating a game and reaching permitted admin actions.
 - [ ] E2E-ADMIN-007: Assigned Admin cannot access global-only routes such as game administrator assignment management.
 - [ ] E2E-ADMIN-008: Non-admin Participant A cannot reach create/edit/admin-only screens by direct URL and is redirected or blocked.
+- [ ] E2E-ADMIN-010: On a readonly past game with cost (Bunq enabled): before payment requests, **Add guest** with `Invited by` / inviter search adds a guest to the roster; after payment requests are sent, inviter search is absent and **Add guest** cannot add new entries (readonly or registration-closed error in the dialog).
 
 ## Game administrator assignment scenarios
 
@@ -141,8 +142,8 @@ Routes: `/bunq-settings` (global admin’s own credentials), `/bunq-settings/use
 Past or readonly games with `paymentAmount > 0`, Bunq enabled for the collecting admin, and no `fullyPaid` flag show **Send payment requests** (`title="Send payment requests to unpaid players"`). Prepare games via UI: create with cost, register players, then move date to the past through **Edit Game Settings** (do not set dates via DB).
 
 - [ ] E2E-BUNQ-PAY-001: Global Admin with Bunq enabled opens a past paid game and sees the send-payment-requests control; an upcoming game with the same cost does not show it.
-- [ ] E2E-BUNQ-PAY-002: Global Admin sends payment requests: click send → password dialog `Please enter your password to send payment requests.` → submit → popup `Payment requests sent` with a success count → dismiss → page shows `Payments collected by` with the admin’s display name.
-- [ ] E2E-BUNQ-PAY-003: After payment requests are sent, active players show `Unpaid` (or `Paid` if already settled); admin remove-player control is no longer available for those rows (see also E2E-BUNQ-LOCK-002 and E2E-BUNQ-LOCK-003).
+- [ ] E2E-BUNQ-PAY-002: Global Admin sends payment requests: click send → password dialog `Please enter your password to send payment requests.` → submit → popup `Payment requests sent` with a success count → dismiss → page shows `Payments collected by` with the admin’s display name, active players show `Unpaid` (or `Paid` if already settled), and roster add/remove controls are locked as in E2E-ADMIN-003 and E2E-ADMIN-004.
+- [ ] E2E-BUNQ-PAY-009: After payment requests were sent for all unpaid active players, **Send payment requests** is hidden or a second send via UI reports zero new requests created.
 - [ ] E2E-BUNQ-PAY-004: Invalid Bunq password on send keeps the password dialog open with `Invalid password` and does not show the success popup.
 - [ ] E2E-BUNQ-PAY-005: Assigned Admin with their own Bunq configured (via CONFIG-009) can send payment requests on a past game they administer; Participant A does not see send-payment controls on the same game.
 - [ ] E2E-BUNQ-PAY-006: Readonly past game with cost and registrations follows the same send-payment-requests flow as a normal past game.
@@ -160,23 +161,3 @@ Status surfaces: per-player `Paid` / `Unpaid` on game details (past/readonly, af
 - [ ] E2E-BUNQ-STATUS-005: Wrong password on per-game check keeps the password dialog open with `Invalid password`.
 - [ ] E2E-BUNQ-STATUS-006: Global Admin opens `/check-payments`, submits password on `Enter Bunq API Password`, sees completion feedback, and returns to games home; past unpaid games reflect updated statuses where the mock reports payment accepted.
 - [ ] E2E-BUNQ-STATUS-007: Participant A on a past game they joined does not see admin paid-status toggles or check-payment/sync controls; they may still see price and their own registration state.
-
-## Roster lock and related flows after payment requests
-
-These scenarios depend on Bunq being enabled and payment requests having been sent on a past (or readonly past) game with `paymentAmount > 0`. Setup entirely through the UI: create game, register players, move game to the past, enable Bunq, send payment requests (see payment-request scenarios). `hasPaymentRequests` is indicated in the UI by `Payments collected by` / `collectorUser`.
-
-### Admin roster changes
-
-- [ ] E2E-BUNQ-LOCK-001: On a past game **before** payment requests are sent, Global Admin sees **Add Participant** (`title="Add Participant"`), adds Participant B via `Search users to add...`, and Participant B appears in the players list.
-- [ ] E2E-BUNQ-LOCK-002: On the same game **after** payment requests are sent, **Add Participant** is no longer shown in admin actions and there is no `Search users to add...` flow.
-- [ ] E2E-BUNQ-LOCK-003: After payment requests are sent, active player rows show `Paid` / `Unpaid` toggles instead of **Remove player**; admin cannot remove a registered player from the roster.
-- [ ] E2E-BUNQ-LOCK-004: On a readonly past game **before** payment requests, Global Admin uses **Add guest**, the guest dialog shows `Invited by` with `Search user (inviter)...`, and a guest registered under an inviter appears in the players list.
-- [ ] E2E-BUNQ-LOCK-005: On a readonly past game **after** payment requests, the guest dialog no longer offers inviter search; **Add guest** cannot add new roster entries (error such as readonly registration closed, or equivalent failure surfaced in the dialog).
-- [ ] E2E-BUNQ-LOCK-006: After payment requests are sent, Global Admin can still open **Edit Game Settings**, change a visible field such as title, save, and see the update on game details (roster lock does not block game metadata edits).
-- [ ] E2E-BUNQ-LOCK-007: After payment requests are sent for all unpaid players, **Send payment requests** is hidden or a second send via UI reports zero new requests created without duplicating roster side effects.
-
-### Participant and admin visibility of outstanding payments
-
-- [ ] E2E-BUNQ-LOCK-008: Participant A who is unpaid on a past game sees a `Your unpaid games` block on the games home (`Upcoming` filter) with that game listed after payment requests were sent.
-- [ ] E2E-BUNQ-LOCK-009: Participant A opens the unpaid-games entry and **Pay now** opens the Bunq payment link in a new browser tab (or window).
-- [ ] E2E-BUNQ-LOCK-010: Global Admin opens **Player details** for a user with outstanding payment requests, sees an `Unpaid games` section listing the game, and **Send payment reminder** completes successfully (UI feedback only; do not assert SMS/Telegram delivery).

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -91,10 +91,12 @@ Use unique phone numbers per test run when tests create mutable state.
 
 ## Game administration scenarios
 
+Participant add/remove on past or readonly games applies only **before** payment requests have been sent (`collectorUser` unset). After requests are sent, use the roster-lock scenarios in the next section instead.
+
 - [ ] E2E-ADMIN-001: Global Admin deletes an upcoming game from game details after confirming the browser prompt.
 - [ ] E2E-ADMIN-002: Global Admin cancels the delete confirmation and the game remains available.
-- [ ] E2E-ADMIN-003: Global Admin adds an existing user to a readonly or past game through the `Search users to add...` admin flow.
-- [ ] E2E-ADMIN-004: Global Admin removes a player from a game and the players list updates.
+- [ ] E2E-ADMIN-003: Global Admin adds an existing user to a readonly or past game through the `Search users to add...` admin flow while payment requests have **not** yet been sent.
+- [ ] E2E-ADMIN-004: Global Admin removes a player from a past or readonly game and the players list updates while payment requests have **not** yet been sent.
 - [ ] E2E-ADMIN-005: Global Admin opens player info from a player row and sees the selected user's public information.
 - [ ] E2E-ADMIN-006: Assigned Admin can manage games for their assigned day/type, including creating a game and reaching permitted admin actions.
 - [ ] E2E-ADMIN-007: Assigned Admin cannot access global-only routes such as game administrator assignment management.
@@ -140,7 +142,7 @@ Past or readonly games with `paymentAmount > 0`, Bunq enabled for the collecting
 
 - [ ] E2E-BUNQ-PAY-001: Global Admin with Bunq enabled opens a past paid game and sees the send-payment-requests control; an upcoming game with the same cost does not show it.
 - [ ] E2E-BUNQ-PAY-002: Global Admin sends payment requests: click send → password dialog `Please enter your password to send payment requests.` → submit → popup `Payment requests sent` with a success count → dismiss → page shows `Payments collected by` with the admin’s display name.
-- [ ] E2E-BUNQ-PAY-003: After payment requests are sent, active players show `Unpaid` (or `Paid` if already settled); admin remove-player control is no longer available for those rows.
+- [ ] E2E-BUNQ-PAY-003: After payment requests are sent, active players show `Unpaid` (or `Paid` if already settled); admin remove-player control is no longer available for those rows (see also E2E-BUNQ-LOCK-002 and E2E-BUNQ-LOCK-003).
 - [ ] E2E-BUNQ-PAY-004: Invalid Bunq password on send keeps the password dialog open with `Invalid password` and does not show the success popup.
 - [ ] E2E-BUNQ-PAY-005: Assigned Admin with their own Bunq configured (via CONFIG-009) can send payment requests on a past game they administer; Participant A does not see send-payment controls on the same game.
 - [ ] E2E-BUNQ-PAY-006: Readonly past game with cost and registrations follows the same send-payment-requests flow as a normal past game.
@@ -158,3 +160,23 @@ Status surfaces: per-player `Paid` / `Unpaid` on game details (past/readonly, af
 - [ ] E2E-BUNQ-STATUS-005: Wrong password on per-game check keeps the password dialog open with `Invalid password`.
 - [ ] E2E-BUNQ-STATUS-006: Global Admin opens `/check-payments`, submits password on `Enter Bunq API Password`, sees completion feedback, and returns to games home; past unpaid games reflect updated statuses where the mock reports payment accepted.
 - [ ] E2E-BUNQ-STATUS-007: Participant A on a past game they joined does not see admin paid-status toggles or check-payment/sync controls; they may still see price and their own registration state.
+
+## Roster lock and related flows after payment requests
+
+These scenarios depend on Bunq being enabled and payment requests having been sent on a past (or readonly past) game with `paymentAmount > 0`. Setup entirely through the UI: create game, register players, move game to the past, enable Bunq, send payment requests (see payment-request scenarios). `hasPaymentRequests` is indicated in the UI by `Payments collected by` / `collectorUser`.
+
+### Admin roster changes
+
+- [ ] E2E-BUNQ-LOCK-001: On a past game **before** payment requests are sent, Global Admin sees **Add Participant** (`title="Add Participant"`), adds Participant B via `Search users to add...`, and Participant B appears in the players list.
+- [ ] E2E-BUNQ-LOCK-002: On the same game **after** payment requests are sent, **Add Participant** is no longer shown in admin actions and there is no `Search users to add...` flow.
+- [ ] E2E-BUNQ-LOCK-003: After payment requests are sent, active player rows show `Paid` / `Unpaid` toggles instead of **Remove player**; admin cannot remove a registered player from the roster.
+- [ ] E2E-BUNQ-LOCK-004: On a readonly past game **before** payment requests, Global Admin uses **Add guest**, the guest dialog shows `Invited by` with `Search user (inviter)...`, and a guest registered under an inviter appears in the players list.
+- [ ] E2E-BUNQ-LOCK-005: On a readonly past game **after** payment requests, the guest dialog no longer offers inviter search; **Add guest** cannot add new roster entries (error such as readonly registration closed, or equivalent failure surfaced in the dialog).
+- [ ] E2E-BUNQ-LOCK-006: After payment requests are sent, Global Admin can still open **Edit Game Settings**, change a visible field such as title, save, and see the update on game details (roster lock does not block game metadata edits).
+- [ ] E2E-BUNQ-LOCK-007: After payment requests are sent for all unpaid players, **Send payment requests** is hidden or a second send via UI reports zero new requests created without duplicating roster side effects.
+
+### Participant and admin visibility of outstanding payments
+
+- [ ] E2E-BUNQ-LOCK-008: Participant A who is unpaid on a past game sees a `Your unpaid games` block on the games home (`Upcoming` filter) with that game listed after payment requests were sent.
+- [ ] E2E-BUNQ-LOCK-009: Participant A opens the unpaid-games entry and **Pay now** opens the Bunq payment link in a new browser tab (or window).
+- [ ] E2E-BUNQ-LOCK-010: Global Admin opens **Player details** for a user with outstanding payment requests, sees an `Unpaid games` section listing the game, and **Send payment reminder** completes successfully (UI feedback only; do not assert SMS/Telegram delivery).

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -4,6 +4,8 @@ Purpose: define the automated end-to-end scenario set for the application using 
 
 Scope: browser-based tests for the Telegram Mini App running locally in dev mode, including Bunq payment integration (configuration, payment requests, and payment status tracking for past games).
 
+**Status:** `[x]` = implemented in `e2e/` (scenario ID matches the test name prefix, e.g. `E2E-HOME-001` in `e2e/games-home.spec.ts`). `[ ]` = planned, not yet automated.
+
 ## Test environment assumptions
 
 - Run the app with dev mode enabled, for example `DEV_MODE=true npm run dev` or `npm run dev:local`, or the Playwright stack via `scripts/playwright-dev-server.sh` (starts backend, mini app, and `bunq-mock`).
@@ -39,125 +41,171 @@ Use unique phone numbers per test run when tests create mutable state.
 
 ## Authentication and session scenarios
 
-- [ ] E2E-AUTH-001: Unauthenticated visitor sees the landing page with `Welcome`, `Telegram`, `Phone number`, and `How it works`.
-- [ ] E2E-AUTH-002: Visitor expands `How it works` and sees the community, registration, notification, cost-sharing explanation, and GitHub source link.
-- [ ] E2E-AUTH-003: Participant A logs in through dev mode with phone number and display name, then lands on the authenticated games home.
-- [ ] E2E-AUTH-004: Global Admin logs in through dev mode with the `Administrator` checkbox selected and sees admin controls on the games home.
-- [ ] E2E-AUTH-005: Two isolated Playwright browser contexts can log in as different users and keep separate displayed names and sessions.
-- [ ] E2E-AUTH-006: Browser-mode header displays the authenticated user's display name, opens the edit display name dialog, saves a new name, and reflects it in the header.
-- [ ] E2E-AUTH-007: Authenticated user logs out and returns to the unauthenticated landing page.
-- [ ] E2E-AUTH-008: Dev login prevents submit until both phone number and display name are provided.
+Spec: `e2e/auth-session.spec.ts`
+
+- [x] E2E-AUTH-001: Unauthenticated visitor sees the landing page with `Welcome`, `Telegram`, `Phone number`, and `How it works`.
+- [x] E2E-AUTH-002: Visitor expands `How it works` and sees the community, registration, notification, cost-sharing explanation, and GitHub source link.
+- [x] E2E-AUTH-003: Participant A logs in through dev mode with phone number and display name, then lands on the authenticated games home.
+- [x] E2E-AUTH-004: Global Admin logs in through dev mode with the `Administrator` checkbox selected and sees admin controls on the games home.
+- [x] E2E-AUTH-005: Two isolated Playwright browser contexts can log in as different users and keep separate displayed names and sessions.
+- [x] E2E-AUTH-006: Browser-mode header displays the authenticated user's display name, opens the edit display name dialog, saves a new name, and reflects it in the header.
+- [x] E2E-AUTH-007: Authenticated user logs out and returns to the unauthenticated landing page.
+- [x] E2E-AUTH-008: Dev login prevents submit until both phone number and display name are provided.
 
 ## Games home scenarios
 
-- [ ] E2E-HOME-001: Participant A loads the games home and sees upcoming games or the `No games available` empty state.
-- [ ] E2E-HOME-002: Participant A opens a game card and reaches the matching game details page.
-- [ ] E2E-HOME-003: Participant A uses the category multi-select on upcoming games and sees the selected category info block.
-- [ ] E2E-HOME-004: A registered participant sees the `You're in` badge for an active registration on the games home.
-- [ ] E2E-HOME-005: A waitlisted participant sees the `Waitlist` badge for a waitlist registration on the games home.
-- [ ] E2E-HOME-006: A game card with a location opens an external maps link without navigating away from the app route.
-- [ ] E2E-HOME-007: Global Admin switches between `Upcoming` and `Past` filters.
-- [ ] E2E-HOME-008: Global Admin toggles `Show all scheduled games` for upcoming games and sees games outside the default registration window.
-- [ ] E2E-HOME-009: Global Admin switches to past games and toggles `Show fully paid games`.
-- [ ] E2E-HOME-010: Global Admin sees `Game Administrators` and `Create New Game` controls for non-integration admin access.
-- [ ] E2E-HOME-011: Assigned Admin sees `Create New Game` access without global-only administration links.
-- [ ] E2E-HOME-012: Home error state shows `Error` and `Retry` when the games API fails, then recovers after retry.
-- [ ] E2E-HOME-013: Participant A with an unpaid past game (after admin sent payment requests) sees `Your unpaid games` on the upcoming home view, opens the entry, and **Pay now** opens the Bunq payment link in a new browser tab (or window).
+Spec: `e2e/games-home.spec.ts`
+
+- [x] E2E-HOME-001: Participant A loads the games home and sees upcoming games or the `No games available` empty state.
+- [x] E2E-HOME-002: Participant A opens a game card and reaches the matching game details page.
+- [x] E2E-HOME-003: Participant A uses the category multi-select on upcoming games and sees the selected category info block.
+- [x] E2E-HOME-004: A registered participant sees the `You're in` badge for an active registration on the games home.
+- [x] E2E-HOME-005: A waitlisted participant sees the `Waitlist` badge for a waitlist registration on the games home.
+- [x] E2E-HOME-006: A game card with a location opens an external maps link without navigating away from the app route.
+- [x] E2E-HOME-007: Global Admin switches between `Upcoming` and `Past` filters.
+- [x] E2E-HOME-008: Global Admin toggles `Show all scheduled games` for upcoming games and sees games outside the default registration window.
+- [x] E2E-HOME-009: Global Admin switches to past games and toggles `Show fully paid games`.
+- [x] E2E-HOME-010: Global Admin sees `Game Administrators` and `Create New Game` controls for non-integration admin access.
+- [x] E2E-HOME-011: Assigned Admin sees `Create New Game` access without global-only administration links.
+- [x] E2E-HOME-012: Home error state shows `Error` and `Retry` when the games API fails, then recovers after retry.
+- [x] E2E-HOME-013: With default category filter (Sunday), participant sees `No games available` when the only upcoming game is a Thursday 5-1 game.
+- [x] E2E-HOME-014: Participant deselects all category options in the multi-select and sees `No games available` even when games exist for other categories.
+- [ ] E2E-HOME-015: Participant A with an unpaid past game (after admin sent payment requests) sees `Your unpaid games` on the upcoming home view, opens the entry, and **Pay now** opens the Bunq payment link in a new browser tab (or window).
 
 ## Game details participant scenarios
 
-- [ ] E2E-GAME-001: Participant A opens an upcoming game and sees date, optional title, location, capacity, price display when configured, players list, and registration action.
-- [ ] E2E-GAME-002: Participant A joins an open upcoming game and sees `You're in` on details and on the games home.
-- [ ] E2E-GAME-003: Participant A leaves a joined game before the unregister deadline and no longer sees `You're in`.
-- [ ] E2E-GAME-004: Participant B joins a full game and lands on the waiting list with the `Waitlist` status.
-- [ ] E2E-GAME-005: Participant A leaves a full game and the next waitlisted participant moves into the active players list.
-- [ ] E2E-GAME-006: Participant A sees the readonly notice and cannot join or leave when a game is marked readonly.
-- [ ] E2E-GAME-007: Participant A sees deadline or registration-closed info text when the unregister deadline has passed.
-- [ ] E2E-GAME-008: Participant A opens a non-existent game id and sees `Error`, `Game not found`, and `Back to Games`.
-- [ ] E2E-GAME-009: Participant A registers a guest when guest registration is allowed and sees the guest in the players list.
-- [ ] E2E-GAME-010: Participant A opens and completes the bring-ball dialog when the game state requires ball assignment.
-- [ ] E2E-GAME-011: Participant A sees seasonal game theming for Halloween, New Year, and March 8 tagged games without breaking core registration actions.
+Spec: `e2e/game-details-participant.spec.ts`
+
+- [x] E2E-GAME-001: Participant A opens an upcoming game and sees date, optional title, location, capacity, price display when configured, players list, and registration action.
+- [x] E2E-GAME-002: Participant A joins an open upcoming game and sees `You're in` on details and on the games home.
+- [x] E2E-GAME-003: Participant A leaves a joined game before the unregister deadline and no longer sees `You're in`.
+- [x] E2E-GAME-004: Participant B joins a full game and lands on the waiting list with the `Waitlist` status.
+- [x] E2E-GAME-005: Participant A leaves a full game and the next waitlisted participant moves into the active players list.
+- [x] E2E-GAME-006: Participant A sees the readonly notice and cannot join or leave when a game is marked readonly.
+- [x] E2E-GAME-007: Participant A sees deadline or registration-closed info text when the unregister deadline has passed.
+- [x] E2E-GAME-008: Participant A opens a non-existent game id and sees `Error`, `Game not found`, and `Back to Games`.
+- [x] E2E-GAME-009: Participant A registers a guest when guest registration is allowed and sees the guest in the players list.
+- [x] E2E-GAME-010: Participant A opens and completes the bring-ball dialog when the game state requires ball assignment.
+- [x] E2E-GAME-011: Participant A sees seasonal game theming for Halloween, New Year, and March 8 tagged games without breaking core registration actions.
+
+## Registration window scenarios
+
+Spec: `e2e/registration-windows-guests-blocked.spec.ts`
+
+- [x] E2E-WIN-001: Participant sees `Registration opens` (10 days before the game) and cannot join when the game is outside the registration window.
+- [x] E2E-WIN-002: Participant can join when registration is open but **Add guest** is hidden before the guest registration window.
+
+## Blocked user scenarios
+
+Spec: `e2e/registration-windows-guests-blocked.spec.ts`
+
+- [x] E2E-BLOCK-001: Global Admin blocks a user from player details with a reason; the blocked user cannot join a game or add a guest and sees the block reason in the dialog.
+
+## Guest registration scenarios
+
+Spec: `e2e/registration-windows-guests-blocked.spec.ts`
+
+- [x] E2E-GUEST-001: Participant unregisters their own guest from the players list via the unregister-guest control and confirmation dialog.
+- [x] E2E-GUEST-002: Global Admin adds a guest on a readonly game using **Invited by** inviter search; the guest appears with inviter attribution in the players list.
 
 ## Game creation and editing scenarios
 
-- [ ] E2E-FORM-001: Global Admin opens `Create New Game` from the games home.
-- [ ] E2E-FORM-002: Global Admin creates a standard game with date/time, maximum players, unregister deadline, per-participant cost, location name, optional location link, and optional title.
-- [ ] E2E-FORM-003: Global Admin creates a game with total-cost pricing and sees the per-participant preview update as maximum players changes.
-- [ ] E2E-FORM-004: Global Admin creates a game with `Playing 5-1` enabled and verifies it appears in the appropriate games list/category behavior.
-- [ ] E2E-FORM-005: Global Admin creates a readonly game and verifies regular participants cannot self-register.
-- [ ] E2E-FORM-006: Global Admin cancels game creation and returns without creating a game.
-- [ ] E2E-FORM-007: Global Admin opens `Edit Game Settings` from game details, updates title/location/capacity/deadline/toggles, saves, and sees the updated details.
-- [ ] E2E-FORM-008: Global Admin cancels editing and returns to game details without persisting changes.
-- [ ] E2E-FORM-009: Required fields and numeric bounds prevent invalid game creation, including missing date, maximum players below minimum, and negative cost.
+Spec: `e2e/game-form.spec.ts`
+
+- [x] E2E-FORM-001: Global Admin opens `Create New Game` from the games home.
+- [x] E2E-FORM-002: Global Admin creates a standard game with date/time, maximum players, unregister deadline, per-participant cost, location name, optional location link, and optional title.
+- [x] E2E-FORM-003: Global Admin creates a game with total-cost pricing and sees the per-participant preview update as maximum players changes.
+- [x] E2E-FORM-004: Global Admin creates a game with `Playing 5-1` enabled and verifies it appears in the appropriate games list/category behavior.
+- [x] E2E-FORM-005: Global Admin creates a readonly game and verifies regular participants cannot self-register.
+- [x] E2E-FORM-006: Global Admin cancels game creation and returns without creating a game.
+- [x] E2E-FORM-007: Global Admin opens `Edit Game Settings` from game details, updates title/location/capacity/deadline/toggles, saves, and sees the updated details.
+- [x] E2E-FORM-008: Global Admin cancels editing and returns to game details without persisting changes.
+- [x] E2E-FORM-009: Required fields and numeric bounds prevent invalid game creation, including missing date, maximum players below minimum, and negative cost.
 - [ ] E2E-FORM-010: On a past game after payment requests were sent, Global Admin still opens **Edit Game Settings**, changes a field such as title, saves, and sees the update on game details (participant roster lock does not block metadata edits).
 
 ## Game administration scenarios
 
-- [ ] E2E-ADMIN-001: Global Admin deletes an upcoming game from game details after confirming the browser prompt.
-- [ ] E2E-ADMIN-002: Global Admin cancels the delete confirmation and the game remains available.
-- [ ] E2E-ADMIN-003: On a past paid game (Bunq enabled, Participant A registered): Global Admin adds Participant B via **Add Participant** and `Search users to add...` before payment requests; sends payment requests; **Add Participant** is then unavailable while B remains on the roster.
-- [ ] E2E-ADMIN-004: On a past or readonly game: Global Admin removes a player before payment requests; after sending payment requests, **Remove player** is unavailable and active rows show **Paid** / **Unpaid** controls instead.
-- [ ] E2E-ADMIN-005: Global Admin opens player info from a player row and sees public information; for a user with outstanding payment requests, also sees `Unpaid games` listing the game and **Send payment reminder** completes with UI success feedback (do not assert SMS/Telegram delivery).
-- [ ] E2E-ADMIN-006: Assigned Admin can manage games for their assigned day/type, including creating a game and reaching permitted admin actions.
-- [ ] E2E-ADMIN-007: Assigned Admin cannot access global-only routes such as game administrator assignment management.
-- [ ] E2E-ADMIN-008: Non-admin Participant A cannot reach create/edit/admin-only screens by direct URL and is redirected or blocked.
-- [ ] E2E-ADMIN-010: On a readonly past game with cost (Bunq enabled): before payment requests, **Add guest** with `Invited by` / inviter search adds a guest to the roster; after payment requests are sent, inviter search is absent and **Add guest** cannot add new entries (readonly or registration-closed error in the dialog).
+Spec: `e2e/game-administration.spec.ts`
+
+- [x] E2E-ADMIN-001: Global Admin deletes an upcoming game from game details after confirming the browser prompt.
+- [x] E2E-ADMIN-002: Global Admin cancels the delete confirmation and the game remains available.
+- [x] E2E-ADMIN-003: Global Admin adds an existing user to a readonly game and to a past game via **Add Participant** and `Search users to add...`.
+- [x] E2E-ADMIN-004: Global Admin removes a player from a readonly game and the players list updates.
+- [x] E2E-ADMIN-005: Global Admin opens player info from a player row and sees the selected user's display name.
+- [x] E2E-ADMIN-006: Assigned Admin can manage games for their assigned day/type, including creating a game and reaching permitted admin actions.
+- [x] E2E-ADMIN-007: Assigned Admin cannot access global-only routes such as game administrator assignment management.
+- [x] E2E-ADMIN-008: Non-admin Participant A cannot reach create/edit/admin-only screens by direct URL and is redirected or blocked.
+- [x] E2E-ADMIN-009: Assigned Admin receives a 403 error when creating a game on a weekday outside their assignment.
+- [x] E2E-ADMIN-010: Assigned Admin receives a 403 error when saving edits to a game outside their assignment.
+- [ ] E2E-ADMIN-011: On a past paid game (Bunq enabled, Participant A registered): Global Admin adds Participant B via **Add Participant** before payment requests; sends payment requests; **Add Participant** is then unavailable while B remains on the roster.
+- [ ] E2E-ADMIN-012: On a past or readonly game: Global Admin removes a player before payment requests; after sending payment requests, **Remove player** is unavailable and active rows show **Paid** / **Unpaid** controls instead.
+- [ ] E2E-ADMIN-013: Global Admin opens player info for a user with outstanding payment requests, sees `Unpaid games` listing the game, and **Send payment reminder** completes with UI success feedback (do not assert SMS/Telegram delivery).
+- [ ] E2E-ADMIN-014: On a readonly past game with cost (Bunq enabled): before payment requests, **Add guest** with `Invited by` / inviter search adds a guest; after payment requests are sent, inviter search is absent and **Add guest** cannot add new entries (readonly or registration-closed error in the dialog).
 
 ## Game administrator assignment scenarios
 
-- [ ] E2E-ASSIGN-001: Global Admin opens `Game Administrators` and sees existing assignments or the empty state.
-- [ ] E2E-ASSIGN-002: Global Admin opens `Add Assignment`, selects day of week, toggles `5-1 positions game`, selects Assigned Admin through user search, and creates the assignment.
-- [ ] E2E-ASSIGN-003: Newly assigned admin appears in the assignments list with day and optional `5-1` badge.
-- [ ] E2E-ASSIGN-004: Global Admin opens player info from an administrator assignment row.
-- [ ] E2E-ASSIGN-005: Global Admin deletes an assignment after confirming the browser prompt.
-- [ ] E2E-ASSIGN-006: Global Admin cancels assignment deletion and the assignment remains.
-- [ ] E2E-ASSIGN-007: Non-admin Participant A is redirected away from `/game-administrators`.
+Spec: `e2e/game-administrators-assignment.spec.ts`
+
+- [x] E2E-ASSIGN-001: Global Admin opens `Game Administrators` and sees existing assignments or the empty state.
+- [x] E2E-ASSIGN-002: Global Admin opens `Add Assignment`, selects day of week, toggles `5-1 positions game`, selects Assigned Admin through user search, and creates the assignment. *(Covered in the same test as ASSIGN-003.)*
+- [x] E2E-ASSIGN-003: Newly assigned admin appears in the assignments list with day and optional `5-1` badge. *(Covered in the same test as ASSIGN-002.)*
+- [x] E2E-ASSIGN-004: Global Admin opens player info from an administrator assignment row.
+- [x] E2E-ASSIGN-005: Global Admin deletes an assignment after confirming the browser prompt.
+- [x] E2E-ASSIGN-006: Global Admin cancels assignment deletion and the assignment remains.
+- [x] E2E-ASSIGN-007: Non-admin Participant A is redirected away from `/game-administrators`.
 
 ## Cross-user and state-transition scenarios
 
-- [ ] E2E-STATE-001: Global Admin creates a game, Participant A joins it in a separate context, and Global Admin sees Participant A in the players list after refresh.
-- [ ] E2E-STATE-002: Participant A and Participant B compete for the last available spot; one becomes active and the other becomes waitlisted deterministically.
-- [ ] E2E-STATE-003: Global Admin edits game capacity downward and the UI preserves valid active/waitlist status for existing registrations.
-- [ ] E2E-STATE-004: Browser refresh keeps the authenticated session and current route for each logged-in persona.
-- [ ] E2E-STATE-005: Opening the app in a new browser context without cookies starts unauthenticated.
+Spec: `e2e/cross-user-state.spec.ts`
 
-## Bunq integration configuration scenarios
+- [x] E2E-STATE-001: Global Admin creates a game, Participant A joins it in a separate context, and Global Admin sees Participant A in the players list after refresh.
+- [x] E2E-STATE-002: Participant A and Participant B compete for the last available spot; one becomes active and the other becomes waitlisted deterministically.
+- [x] E2E-STATE-003: Global Admin edits game capacity downward and the UI preserves valid active/waitlist status for existing registrations.
+- [x] E2E-STATE-004: Browser refresh keeps the authenticated session and current route for each logged-in persona.
+- [x] E2E-STATE-005: Opening the app in a new browser context without cookies starts unauthenticated.
+
+## Bunq webhook and payment status (implemented)
+
+Spec: `e2e/bunq-webhook.spec.ts`
+
+- [x] E2E-BUNQ-001: Admin enables Bunq via settings UI, moves game to the past, sends payment requests; bunq-mock delivers `REQUEST_INQUIRY_ACCEPTED` for the participant's inquiry (control plane); after reload the player row shows `Paid`.
+
+## Bunq integration configuration scenarios (planned)
 
 Routes: `/bunq-settings` (global admin’s own credentials), `/bunq-settings/user/:assignedUserId` (global admin configuring an assigned game administrator’s credentials). Entry points: games home **Bunq Settings** cog (`title="Bunq Settings"`), or **Configure Bunq Settings** on a row in `Game Administrators`.
 
 - [ ] E2E-BUNQ-CONFIG-001: Global Admin opens Bunq Settings from the games home and sees `Bunq Settings`, loading complete, and status text `Bunq integration is disabled`.
 - [ ] E2E-BUNQ-CONFIG-002: Global Admin clicks `Enable Bunq Integration`, sees `Specify Bunq API Credentials` with API Key, API Key Name, and Password fields, and cannot submit until all three are filled.
 - [ ] E2E-BUNQ-CONFIG-003: Global Admin submits valid mock credentials (`Enable Integration`) and sees `Bunq integration enabled successfully` and status `Bunq integration is enabled`.
-- [ ] E2E-BUNQ-CONFIG-004: With integration enabled, Global Admin uses `Choose account to receive payments to`, enters the Bunq password, clicks `Load Accounts`, selects a monetary account from `Choose account to receive payments to`, and sees `Bunq account updated successfully!` (or equivalent success feedback).
+- [ ] E2E-BUNQ-CONFIG-004: With integration enabled, Global Admin uses `Choose account to receive payments to`, enters the Bunq password, clicks `Load Accounts`, selects a monetary account, and sees success feedback.
 - [ ] E2E-BUNQ-CONFIG-005: Global Admin clicks `Install Webhook`, enters the Bunq password in `Install Bunq Webhook`, submits, and sees success feedback without leaving the settings page.
 - [ ] E2E-BUNQ-CONFIG-006: Global Admin opens `Update API Key`, cancels via `Cancel`, and returns to the enabled settings view without changing status.
-- [ ] E2E-BUNQ-CONFIG-007: Global Admin disables integration: `Disable Integration` → confirm browser/Telegram prompt → `Bunq integration disabled successfully` and status returns to disabled.
+- [ ] E2E-BUNQ-CONFIG-007: Global Admin disables integration: `Disable Integration` → confirm prompt → `Bunq integration disabled successfully` and status returns to disabled.
 - [ ] E2E-BUNQ-CONFIG-008: Global Admin cancels disable at the confirmation prompt and integration remains enabled.
-- [ ] E2E-BUNQ-CONFIG-009: Global Admin opens `Game Administrators`, uses **Configure Bunq Settings** for Assigned Admin, sees `Bunq Settings (<display name>)`, and completes enable flow for that user (same credential form as own settings).
+- [ ] E2E-BUNQ-CONFIG-009: Global Admin opens `Game Administrators`, uses **Configure Bunq Settings** for Assigned Admin, sees `Bunq Settings (<display name>)`, and completes enable flow for that user.
 - [ ] E2E-BUNQ-CONFIG-010: Participant A navigates to `/bunq-settings` and is redirected away or blocked from managing Bunq credentials.
 - [ ] E2E-BUNQ-CONFIG-011: Wrong Bunq password on enable or webhook install shows an inline error and keeps the user on the relevant form/dialog.
 
-## Bunq payment request scenarios
+## Bunq payment request scenarios (planned)
 
 Past or readonly games with `paymentAmount > 0`, Bunq enabled for the collecting admin, and no `fullyPaid` flag show **Send payment requests** (`title="Send payment requests to unpaid players"`). Prepare games via UI: create with cost, register players, then move date to the past through **Edit Game Settings** (do not set dates via DB).
 
 - [ ] E2E-BUNQ-PAY-001: Global Admin with Bunq enabled opens a past paid game and sees the send-payment-requests control; an upcoming game with the same cost does not show it.
-- [ ] E2E-BUNQ-PAY-002: Global Admin sends payment requests: click send → password dialog `Please enter your password to send payment requests.` → submit → popup `Payment requests sent` with a success count → dismiss → page shows `Payments collected by` with the admin’s display name, active players show `Unpaid` (or `Paid` if already settled), and roster add/remove controls are locked as in E2E-ADMIN-003 and E2E-ADMIN-004.
-- [ ] E2E-BUNQ-PAY-009: After payment requests were sent for all unpaid active players, **Send payment requests** is hidden or a second send via UI reports zero new requests created.
+- [ ] E2E-BUNQ-PAY-002: Global Admin sends payment requests: password dialog → popup `Payment requests sent` → `Payments collected by` with admin display name, active players show `Unpaid` (or `Paid` if settled), and roster add/remove controls are locked as in E2E-ADMIN-011 and E2E-ADMIN-012.
+- [ ] E2E-BUNQ-PAY-003: After payment requests were sent for all unpaid active players, **Send payment requests** is hidden or a second send via UI reports zero new requests created.
 - [ ] E2E-BUNQ-PAY-004: Invalid Bunq password on send keeps the password dialog open with `Invalid password` and does not show the success popup.
 - [ ] E2E-BUNQ-PAY-005: Assigned Admin with their own Bunq configured (via CONFIG-009) can send payment requests on a past game they administer; Participant A does not see send-payment controls on the same game.
 - [ ] E2E-BUNQ-PAY-006: Readonly past game with cost and registrations follows the same send-payment-requests flow as a normal past game.
 - [ ] E2E-BUNQ-PAY-007: Game with zero cost does not show send-payment-requests even when past and Bunq is enabled.
 - [ ] E2E-BUNQ-PAY-008: Past game already marked fully paid on the games home does not show send-payment-requests on game details.
 
-## Bunq payment status scenarios (past games)
+## Bunq payment status scenarios (planned)
 
 Status surfaces: per-player `Paid` / `Unpaid` on game details (past/readonly, after requests sent), **Check payment status for this game** sync button on game details, paid/total counters on past game cards, and `Show fully paid games` on the past filter. Optional bulk route: `/check-payments` (password dialog on load; no in-app nav link today—use only if testing that screen explicitly).
 
-- [ ] E2E-BUNQ-STATUS-001: After admin sends payment requests, bunq-mock delivers `REQUEST_INQUIRY_ACCEPTED` for the participant’s inquiry (control plane); reload game details and the player row shows `Paid`. *(Implemented as `E2E-BUNQ-001` in `e2e/bunq-webhook.spec.ts`.)*
-- [ ] E2E-BUNQ-STATUS-002: Global Admin clicks **Check payment status for this game**, enters the Bunq password, sees `Payment check completed`, and unpaid players update to `Paid` when the mock reports inquiry status `ACCEPTED` (webhook delivery or future mock status helper—do not assert via DB).
+- [ ] E2E-BUNQ-STATUS-002: Global Admin clicks **Check payment status for this game**, enters the Bunq password, sees `Payment check completed`, and unpaid players update to `Paid` when the mock reports inquiry status `ACCEPTED`.
 - [ ] E2E-BUNQ-STATUS-003: Global Admin toggles a player from `Unpaid` to `Paid` and back via the paid-status control on the player row; counts on the games home past list update after refresh.
-- [ ] E2E-BUNQ-STATUS-004: When all active players are paid, the past game card shows matching paid/total counts (e.g. `2/2`); with `Show fully paid games` unchecked, the game is hidden from the past list until the toggle is enabled (extends HOME-009 with Bunq-driven fully-paid state via UI, not `updateGame` for `fully_paid`).
+- [ ] E2E-BUNQ-STATUS-004: When all active players are paid, the past game card shows matching paid/total counts (e.g. `2/2`); with `Show fully paid games` unchecked, the game is hidden from the past list until the toggle is enabled (extends HOME-009 with Bunq-driven fully-paid state via UI).
 - [ ] E2E-BUNQ-STATUS-005: Wrong password on per-game check keeps the password dialog open with `Invalid password`.
 - [ ] E2E-BUNQ-STATUS-006: Global Admin opens `/check-payments`, submits password on `Enter Bunq API Password`, sees completion feedback, and returns to games home; past unpaid games reflect updated statuses where the mock reports payment accepted.
 - [ ] E2E-BUNQ-STATUS-007: Participant A on a past game they joined does not see admin paid-status toggles or check-payment/sync controls; they may still see price and their own registration state.

--- a/docs/playwright-e2e-scenarios.md
+++ b/docs/playwright-e2e-scenarios.md
@@ -1,0 +1,156 @@
+# Playwright E2E Scenario Checklist
+
+Purpose: define the first automated end-to-end scenario set for the application using Playwright.
+
+Scope: browser-based tests for the Telegram Mini App running locally in dev mode. Bunq integration features are intentionally excluded for now.
+
+## Test environment assumptions
+
+- Run the app with dev mode enabled, for example `DEV_MODE=true npm run dev` or `npm run dev:local`.
+- Target the frontend at `http://127.0.0.1:3001`; the Vite proxy forwards `/api` requests to the backend.
+- Use the visible dev-mode phone login flow instead of Telegram auth:
+  - Open the landing page.
+  - Choose `Phone number`.
+  - Enter a local Dutch phone number after the fixed `+31` prefix.
+  - Enter a display name.
+  - Toggle `Administrator` only for personas that need global admin rights.
+  - Submit `Dev Login`.
+- Use isolated browser contexts for each persona so cookies do not leak between tests.
+- Prefer deterministic setup through backend APIs or database fixtures before each scenario. UI assertions should still cover the browser flow under test.
+
+## Dev login personas
+
+Use unique phone numbers per test run when tests create mutable state.
+
+- Participant A: non-admin user for normal registration and profile flows.
+- Participant B: non-admin user for capacity, waitlist, priority-player, and multi-user scenarios.
+- Global Admin: dev login with `Administrator` checked.
+- Assigned Admin: non-admin user who becomes a game administrator through an assignment created by Global Admin.
+- Priority Player: non-admin user added to an assignment's priority-player list.
+
+## Out of scope for this checklist
+
+Do not automate these scenarios yet:
+
+- `/bunq-settings`
+- `/bunq-settings/user/:assignedUserId`
+- `/check-payments`
+- Game details actions that send payment requests.
+- Game details actions that check payment status through Bunq.
+- Bunq credential setup, Bunq password dialogs, or Bunq-backed payment reconciliation.
+
+Payment amount display and non-Bunq paid-state UI can be covered only when the scenario does not depend on Bunq APIs.
+
+## Authentication and session scenarios
+
+- [ ] E2E-AUTH-001: Unauthenticated visitor sees the landing page with `Welcome`, `Telegram`, `Phone number`, `How it works`, and the GitHub source link.
+- [ ] E2E-AUTH-002: Visitor expands `How it works` and sees the community, registration, notification, and cost-sharing explanation.
+- [ ] E2E-AUTH-003: Participant A logs in through dev mode with phone number and display name, then lands on the authenticated games home.
+- [ ] E2E-AUTH-004: Global Admin logs in through dev mode with the `Administrator` checkbox selected and sees admin controls on the games home.
+- [ ] E2E-AUTH-005: Two isolated Playwright browser contexts can log in as different users and keep separate displayed names and sessions.
+- [ ] E2E-AUTH-006: Browser-mode header displays the authenticated user's display name, opens the edit display name dialog, saves a new name, and reflects it in the header.
+- [ ] E2E-AUTH-007: Authenticated user logs out and returns to the unauthenticated landing page.
+- [ ] E2E-AUTH-008: Dev login prevents submit until both phone number and display name are provided.
+
+## Games home scenarios
+
+- [ ] E2E-HOME-001: Participant A loads the games home and sees upcoming games or the `No games available` empty state.
+- [ ] E2E-HOME-002: Participant A opens a game card and reaches the matching game details page.
+- [ ] E2E-HOME-003: Participant A uses the category multi-select on upcoming games and sees the selected category info block.
+- [ ] E2E-HOME-004: A registered participant sees the `You're in` badge for an active registration on the games home.
+- [ ] E2E-HOME-005: A waitlisted participant sees the `Waitlist` badge for a waitlist registration on the games home.
+- [ ] E2E-HOME-006: A game card with a location opens an external maps link without navigating away from the app route.
+- [ ] E2E-HOME-007: Global Admin switches between `Upcoming` and `Past` filters.
+- [ ] E2E-HOME-008: Global Admin toggles `Show all scheduled games` for upcoming games and sees games outside the default registration window.
+- [ ] E2E-HOME-009: Global Admin switches to past games and toggles `Show fully paid games`.
+- [ ] E2E-HOME-010: Global Admin sees `Game Administrators` and `Create New Game` controls for non-integration admin access.
+- [ ] E2E-HOME-011: Assigned Admin sees `Create New Game` access without global-only administration links.
+- [ ] E2E-HOME-012: Home error state shows `Error` and `Retry` when the games API fails, then recovers after retry.
+
+## Game details participant scenarios
+
+- [ ] E2E-GAME-001: Participant A opens an upcoming game and sees date, optional title, location, capacity, price display when configured, players list, and registration action.
+- [ ] E2E-GAME-002: Participant A joins an open upcoming game and sees `You're in` on details and on the games home.
+- [ ] E2E-GAME-003: Participant A leaves a joined game before the unregister deadline and no longer sees `You're in`.
+- [ ] E2E-GAME-004: Participant B joins a full game and lands on the waiting list with the `Waitlist` status.
+- [ ] E2E-GAME-005: Participant A leaves a full game and the next waitlisted participant moves into the active players list.
+- [ ] E2E-GAME-006: Participant A sees the readonly notice and cannot join or leave when a game is marked readonly.
+- [ ] E2E-GAME-007: Participant A sees deadline or registration-closed info text when the unregister deadline has passed.
+- [ ] E2E-GAME-008: Participant A opens a non-existent game id and sees `Error`, `Game not found`, and `Back to Games`.
+- [ ] E2E-GAME-009: Participant A registers a guest when guest registration is allowed and sees the guest in the players list.
+- [ ] E2E-GAME-010: Participant A opens and completes the bring-ball dialog when the game state requires ball assignment.
+- [ ] E2E-GAME-011: Participant A sees seasonal game theming for Halloween, New Year, and March 8 tagged games without breaking core registration actions.
+
+## Game creation and editing scenarios
+
+- [ ] E2E-FORM-001: Global Admin opens `Create New Game` from the games home.
+- [ ] E2E-FORM-002: Global Admin creates a standard game with date/time, maximum players, unregister deadline, per-participant cost, location name, optional location link, and optional title.
+- [ ] E2E-FORM-003: Global Admin creates a game with total-cost pricing and sees the per-participant preview update as maximum players changes.
+- [ ] E2E-FORM-004: Global Admin creates a game with `Playing 5-1` enabled and verifies it appears in the appropriate games list/category behavior.
+- [ ] E2E-FORM-005: Global Admin creates a game with `With priority players` enabled for a day/type that has priority players configured.
+- [ ] E2E-FORM-006: Global Admin creates a readonly game and verifies regular participants cannot self-register.
+- [ ] E2E-FORM-007: Global Admin cancels game creation and returns without creating a game.
+- [ ] E2E-FORM-008: Global Admin opens `Edit Game Settings` from game details, updates title/location/capacity/deadline/toggles, saves, and sees the updated details.
+- [ ] E2E-FORM-009: Global Admin cancels editing and returns to game details without persisting changes.
+- [ ] E2E-FORM-010: Required fields and numeric bounds prevent invalid game creation, including missing date, maximum players below minimum, and negative cost.
+
+## Game administration scenarios
+
+- [ ] E2E-ADMIN-001: Global Admin deletes an upcoming game from game details after confirming the browser prompt.
+- [ ] E2E-ADMIN-002: Global Admin cancels the delete confirmation and the game remains available.
+- [ ] E2E-ADMIN-003: Global Admin adds an existing user to a readonly or past game through the `Search users to add...` admin flow.
+- [ ] E2E-ADMIN-004: Global Admin removes a player from a game and the players list updates.
+- [ ] E2E-ADMIN-005: Global Admin removes a waitlisted player and the waiting list updates.
+- [ ] E2E-ADMIN-006: Global Admin opens player info from a player row and sees the selected user's public information.
+- [ ] E2E-ADMIN-007: Assigned Admin can manage games for their assigned day/type, including creating a game and reaching permitted admin actions.
+- [ ] E2E-ADMIN-008: Assigned Admin cannot access global-only routes such as game administrator assignment management.
+- [ ] E2E-ADMIN-009: Non-admin Participant A cannot reach create/edit/admin-only screens by direct URL and is redirected or blocked.
+
+## Game administrator assignment scenarios
+
+- [ ] E2E-ASSIGN-001: Global Admin opens `Game Administrators` and sees existing assignments or the empty state.
+- [ ] E2E-ASSIGN-002: Global Admin opens `Add Assignment`, selects day of week, toggles `5-1 positions game`, selects Assigned Admin through user search, and creates the assignment.
+- [ ] E2E-ASSIGN-003: Newly assigned admin appears in the assignments list with day and optional `5-1` badge.
+- [ ] E2E-ASSIGN-004: Global Admin opens player info from an administrator assignment row.
+- [ ] E2E-ASSIGN-005: Global Admin deletes an assignment after confirming the browser prompt.
+- [ ] E2E-ASSIGN-006: Global Admin cancels assignment deletion and the assignment remains.
+- [ ] E2E-ASSIGN-007: Non-admin Participant A is redirected away from `/game-administrators`.
+
+## Priority player scenarios
+
+- [ ] E2E-PRIORITY-001: Global Admin opens `Manage Priority Players` for an administrator assignment.
+- [ ] E2E-PRIORITY-002: Global Admin sees the `No priority players yet.` empty state before adding players.
+- [ ] E2E-PRIORITY-003: Global Admin adds Priority Player through `Search users to add...` and sees the user in the priority-player list.
+- [ ] E2E-PRIORITY-004: Global Admin opens player info from a priority-player row.
+- [ ] E2E-PRIORITY-005: Global Admin deletes a priority-player assignment after confirming the browser prompt.
+- [ ] E2E-PRIORITY-006: Global Admin cancels priority-player deletion and the assignment remains.
+- [ ] E2E-PRIORITY-007: Assigned Admin can manage priority players only for their own game administrator assignment.
+- [ ] E2E-PRIORITY-008: Participant A cannot manage another user's priority-player assignment and is redirected to the allowed page.
+- [ ] E2E-PRIORITY-009: Invalid priority-player assignment ids redirect back to `Game Administrators`.
+
+## Cross-user and state-transition scenarios
+
+- [ ] E2E-STATE-001: Global Admin creates a game, Participant A joins it in a separate context, and Global Admin sees Participant A in the players list after refresh.
+- [ ] E2E-STATE-002: Participant A and Participant B compete for the last available spot; one becomes active and the other becomes waitlisted deterministically.
+- [ ] E2E-STATE-003: Global Admin edits game capacity downward and the UI preserves valid active/waitlist status for existing registrations.
+- [ ] E2E-STATE-004: Priority Player receives priority behavior for a priority-enabled game while a non-priority participant follows the normal registration order.
+- [ ] E2E-STATE-005: Browser refresh keeps the authenticated session and current route for each logged-in persona.
+- [ ] E2E-STATE-006: Opening the app in a new browser context without cookies starts unauthenticated.
+
+## Accessibility and browser-mode smoke scenarios
+
+- [ ] E2E-A11Y-001: Core unauthenticated, games home, game details, create game, and admin pages expose exactly one main landmark.
+- [ ] E2E-A11Y-002: Primary form controls have accessible labels matching visible labels.
+- [ ] E2E-A11Y-003: Keyboard-only user can log in, open filters, create a game, and submit/cancel dialogs.
+- [ ] E2E-A11Y-004: Browser-mode brand link `Haarlem Volley Bot` returns to the games home from nested routes.
+- [ ] E2E-A11Y-005: Modal dialogs keep actionable controls reachable by keyboard and close through cancel/escape paths where supported.
+
+## Suggested implementation order
+
+1. Dev login helpers and browser-context persona fixtures.
+2. Auth/session smoke tests.
+3. Game creation fixture helpers through UI plus API/database cleanup.
+4. Participant registration flows.
+5. Admin assignment and priority-player flows.
+6. Negative access-control and API-failure recovery scenarios.
+7. Accessibility smoke coverage.

--- a/e2e/auth-session.spec.ts
+++ b/e2e/auth-session.spec.ts
@@ -1,0 +1,180 @@
+import { expect, test, type APIRequestContext, type Page, type TestInfo } from '@playwright/test';
+
+type DevLoginOptions = {
+  displayName: string;
+  phoneLocal: string;
+  isAdmin?: boolean;
+};
+
+async function waitForBackend(request: APIRequestContext) {
+  await expect
+    .poll(
+      async () => {
+        try {
+          const response = await request.get('/api/health', { timeout: 5_000 });
+          return response.status();
+        } catch {
+          return 0;
+        }
+      },
+      { timeout: 45_000, message: 'backend health endpoint should be reachable through Vite proxy' }
+    )
+    .toBe(200);
+}
+
+function uniquePhoneLocal(testInfo: TestInfo, suffix: number) {
+  const timestamp = Date.now().toString().slice(-8);
+  return `6${timestamp}${testInfo.workerIndex}${suffix}`;
+}
+
+function uniqueName(testInfo: TestInfo, label: string) {
+  return `E2E ${label} ${testInfo.workerIndex}-${Date.now().toString().slice(-5)}`;
+}
+
+async function openDevLogin(page: Page) {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+  await page.getByRole('button', { name: 'Phone number' }).click();
+  await expect(page.getByText('Dev mode: No SMS verification required')).toBeVisible();
+}
+
+async function devLogin(page: Page, options: DevLoginOptions) {
+  await openDevLogin(page);
+  await page.getByLabel('Phone number').fill(options.phoneLocal);
+  await page.getByLabel('Display name').fill(options.displayName);
+
+  if (options.isAdmin) {
+    await page.getByLabel('Administrator').check();
+  }
+
+  await page.getByRole('button', { name: 'Dev Login' }).click();
+  await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible();
+  await expect(page.getByText(options.displayName)).toBeVisible();
+}
+
+test.describe('authentication and session scenarios', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+  });
+
+  test('E2E-AUTH-001 unauthenticated visitor sees landing page choices', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+    await expect(page.getByText('Choose how you want to continue:')).toBeVisible();
+    await expect(page.getByText('Telegram')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Phone number' })).toBeVisible();
+    await expect(page.getByText('How it works')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Source code at GitHub' })).toBeVisible();
+  });
+
+  test('E2E-AUTH-002 visitor expands How it works content', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByText('How it works').click();
+
+    await expect(page.getByText('non-profit, recreational volleyball community')).toBeVisible();
+    await expect(page.getByText('register for any game')).toBeVisible();
+    await expect(page.getByText('payment requests and important notifications')).toBeVisible();
+    await expect(page.getByText('cover the cost of the hall rental')).toBeVisible();
+  });
+
+  test('E2E-AUTH-003 participant logs in through dev mode', async ({ page }, testInfo) => {
+    const displayName = uniqueName(testInfo, 'Participant');
+
+    await devLogin(page, {
+      displayName,
+      phoneLocal: uniquePhoneLocal(testInfo, 1),
+    });
+
+    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible();
+    await expect(page.getByLabel('Edit display name')).toContainText(displayName);
+  });
+
+  test('E2E-AUTH-004 global admin logs in through dev mode and sees admin controls', async ({ page }, testInfo) => {
+    await devLogin(page, {
+      displayName: uniqueName(testInfo, 'Admin'),
+      phoneLocal: uniquePhoneLocal(testInfo, 2),
+      isAdmin: true,
+    });
+
+    await expect(page.getByTitle('Game Administrators')).toBeVisible();
+    await expect(page.getByTitle('Create New Game')).toBeVisible();
+  });
+
+  test('E2E-AUTH-005 isolated browser contexts keep separate users', async ({ browser }, testInfo) => {
+    const participantName = uniqueName(testInfo, 'Context A');
+    const adminName = uniqueName(testInfo, 'Context B');
+    const participantContext = await browser.newContext();
+    const adminContext = await browser.newContext();
+
+    try {
+      const participantPage = await participantContext.newPage();
+      const adminPage = await adminContext.newPage();
+
+      await devLogin(participantPage, {
+        displayName: participantName,
+        phoneLocal: uniquePhoneLocal(testInfo, 3),
+      });
+      await devLogin(adminPage, {
+        displayName: adminName,
+        phoneLocal: uniquePhoneLocal(testInfo, 4),
+        isAdmin: true,
+      });
+
+      await expect(participantPage.getByLabel('Edit display name')).toContainText(participantName);
+      await expect(participantPage.getByText(adminName)).toHaveCount(0);
+      await expect(adminPage.getByLabel('Edit display name')).toContainText(adminName);
+      await expect(adminPage.getByTitle('Create New Game')).toBeVisible();
+    } finally {
+      await participantContext.close();
+      await adminContext.close();
+    }
+  });
+
+  test('E2E-AUTH-006 user edits display name and header updates', async ({ page }, testInfo) => {
+    const originalName = uniqueName(testInfo, 'Rename');
+    const updatedName = `${originalName} Updated`;
+
+    await devLogin(page, {
+      displayName: originalName,
+      phoneLocal: uniquePhoneLocal(testInfo, 5),
+    });
+    await page.getByLabel('Edit display name').click();
+    await expect(page.getByRole('heading', { name: 'Edit display name' })).toBeVisible();
+
+    await page.getByLabel('Display name').fill(updatedName);
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Edit display name' })).toHaveCount(0);
+    await expect(page.getByLabel('Edit display name')).toContainText(updatedName);
+  });
+
+  test('E2E-AUTH-007 authenticated user logs out to landing page', async ({ page }, testInfo) => {
+    await devLogin(page, {
+      displayName: uniqueName(testInfo, 'Logout'),
+      phoneLocal: uniquePhoneLocal(testInfo, 6),
+    });
+
+    await page.getByRole('button', { name: 'Logout' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Phone number' })).toBeVisible();
+  });
+
+  test('E2E-AUTH-008 dev login requires both phone and display name', async ({ page }, testInfo) => {
+    await openDevLogin(page);
+
+    const devLoginButton = page.getByRole('button', { name: 'Dev Login' });
+    await expect(devLoginButton).toBeDisabled();
+
+    await page.getByLabel('Phone number').fill(uniquePhoneLocal(testInfo, 7));
+    await expect(devLoginButton).toBeDisabled();
+
+    await page.getByLabel('Display name').fill(uniqueName(testInfo, 'Validation'));
+    await expect(devLoginButton).toBeEnabled();
+
+    await page.getByLabel('Phone number').fill('');
+    await expect(devLoginButton).toBeDisabled();
+  });
+});

--- a/e2e/auth-session.spec.ts
+++ b/e2e/auth-session.spec.ts
@@ -65,7 +65,6 @@ test.describe('authentication and session scenarios', () => {
     await expect(page.locator('.landing-button.telegram').getByText('Telegram')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Phone number' })).toBeVisible();
     await expect(page.getByText('How it works')).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Source code at GitHub' })).toBeVisible();
   });
 
   test('E2E-AUTH-002 visitor expands How it works content', async ({ page }) => {
@@ -77,6 +76,7 @@ test.describe('authentication and session scenarios', () => {
     await expect(page.getByText('register for any game')).toBeVisible();
     await expect(page.getByText('payment requests and important notifications')).toBeVisible();
     await expect(page.getByText('cover the cost of the hall rental')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Source code at GitHub' })).toBeVisible();
   });
 
   test('E2E-AUTH-003 participant logs in through dev mode', async ({ page }, testInfo) => {

--- a/e2e/auth-session.spec.ts
+++ b/e2e/auth-session.spec.ts
@@ -62,7 +62,7 @@ test.describe('authentication and session scenarios', () => {
 
     await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
     await expect(page.getByText('Choose how you want to continue:')).toBeVisible();
-    await expect(page.getByText('Telegram')).toBeVisible();
+    await expect(page.locator('.landing-button.telegram').getByText('Telegram')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Phone number' })).toBeVisible();
     await expect(page.getByText('How it works')).toBeVisible();
     await expect(page.getByRole('link', { name: 'Source code at GitHub' })).toBeVisible();
@@ -143,7 +143,7 @@ test.describe('authentication and session scenarios', () => {
     await page.getByLabel('Edit display name').click();
     await expect(page.getByRole('heading', { name: 'Edit display name' })).toBeVisible();
 
-    await page.getByLabel('Display name').fill(updatedName);
+    await page.getByRole('textbox', { name: 'Display name' }).fill(updatedName);
     await page.getByRole('button', { name: 'Save' }).click();
 
     await expect(page.getByRole('heading', { name: 'Edit display name' })).toHaveCount(0);

--- a/e2e/bunq-config.spec.ts
+++ b/e2e/bunq-config.spec.ts
@@ -1,0 +1,242 @@
+import { expect, test } from '@playwright/test';
+import {
+  BUNQ_E2E_API_KEY,
+  BUNQ_E2E_API_KEY_NAME,
+  BUNQ_E2E_PASSWORD,
+  cleanupE2eData,
+  createDevUserViaApi,
+  devLoginAs,
+  disableBunqIntegrationViaUi,
+  enableBunqIntegrationViaUi,
+  fillBunqCredentialsForm,
+  installBunqWebhookViaUi,
+  loadMonetaryAccountsViaUi,
+  openBunqCredentialsForm,
+  openBunqSettingsFromGamesHome,
+  resetBunqMock,
+  submitBunqCredentialsForm,
+  waitForBackend,
+  waitForBunqSettingsReady,
+} from './support/fixtures';
+
+async function createAdminAssignmentForUser(
+  page: import('@playwright/test').Page,
+  assigneeDisplayName: string
+) {
+  await page.goto('/game-administrators');
+  await expect(page.getByRole('heading', { name: 'Game Administrators' })).toBeVisible();
+  await page.getByRole('button', { name: 'Add Assignment' }).click();
+  await expect(page.getByRole('heading', { name: 'New Assignment' })).toBeVisible();
+  await page.getByLabel('Day of Week').selectOption('6');
+  await page.getByRole('checkbox', { name: /5-1 positions game/i }).uncheck();
+  await page.getByPlaceholder('Search for a user...').fill(assigneeDisplayName);
+  await page.getByText(assigneeDisplayName, { exact: true }).click();
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(page.getByText(assigneeDisplayName)).toBeVisible();
+}
+
+test.describe('Bunq integration configuration scenarios', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await resetBunqMock();
+    await cleanupE2eData();
+  });
+
+  test('E2E-BUNQ-CONFIG-001 global admin opens Bunq Settings from games home', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Bunq Config Home Admin', true);
+    await devLoginAs(page, admin);
+
+    await openBunqSettingsFromGamesHome(page);
+
+    await expect(page).toHaveURL(/\/bunq-settings$/);
+    await expect(page.getByText(/Bunq integration is disabled/)).toBeVisible();
+  });
+
+  test('E2E-BUNQ-CONFIG-002 credentials form requires all fields before submit', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Bunq Config Form Admin', true);
+    await devLoginAs(page, admin);
+    await page.goto('/bunq-settings');
+    await waitForBunqSettingsReady(page);
+
+    await openBunqCredentialsForm(page);
+    const submit = page.getByRole('button', { name: 'Enable Integration' });
+    await expect(submit).toBeDisabled();
+
+    await page.locator('#apiKey').fill(BUNQ_E2E_API_KEY);
+    await expect(submit).toBeDisabled();
+
+    await page.locator('#apiKeyName').fill(BUNQ_E2E_API_KEY_NAME);
+    await expect(submit).toBeDisabled();
+
+    await page.locator('.credentials-form #password').fill(BUNQ_E2E_PASSWORD);
+    await expect(submit).toBeEnabled();
+  });
+
+  test('E2E-BUNQ-CONFIG-003 global admin enables Bunq integration with mock credentials', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Bunq Config Enable Admin', true);
+    await devLoginAs(page, admin);
+    await page.goto('/bunq-settings');
+    await waitForBunqSettingsReady(page);
+
+    await openBunqCredentialsForm(page);
+    await fillBunqCredentialsForm(page, {
+      apiKey: BUNQ_E2E_API_KEY,
+      apiKeyName: BUNQ_E2E_API_KEY_NAME,
+      password: BUNQ_E2E_PASSWORD,
+    });
+    await submitBunqCredentialsForm(page);
+
+    await expect(page.getByText(/Bunq integration enabled successfully/i)).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByText(/Bunq integration is enabled/)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Disable Integration' })).toBeVisible();
+  });
+
+  test('E2E-BUNQ-CONFIG-004 global admin loads and selects a monetary account', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Bunq Config Account Admin', true);
+    await devLoginAs(page, admin);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.reload();
+    await waitForBunqSettingsReady(page);
+    await expect(page.getByText(/Bunq integration is enabled/)).toBeVisible();
+
+    await loadMonetaryAccountsViaUi(page, BUNQ_E2E_PASSWORD);
+    await expect(page.locator('#monetaryAccount')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator('#monetaryAccount')).toContainText('E2E mock EUR account');
+
+    const updatePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PUT' &&
+        /\/api\/users\/me\/bunq\/monetary-account$/.test(new URL(response.url()).pathname)
+    );
+    await page.locator('#monetaryAccount').selectOption({ label: 'E2E mock EUR account' });
+    const updateResponse = await updatePromise;
+    expect(updateResponse.ok()).toBeTruthy();
+
+    await expect(page.getByText(/Bunq account updated successfully/i)).toBeVisible();
+  });
+
+  test('E2E-BUNQ-CONFIG-005 global admin installs webhook from settings page', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Bunq Config Webhook Admin', true);
+    await devLoginAs(page, admin);
+    await enableBunqIntegrationViaUi(page);
+
+    await installBunqWebhookViaUi(page, BUNQ_E2E_PASSWORD);
+
+    await expect(page.getByText(/Webhook installed successfully/i)).toBeVisible({ timeout: 30_000 });
+    await expect(page).toHaveURL(/\/bunq-settings$/);
+    await expect(page.getByRole('heading', { name: 'Bunq Settings' })).toBeVisible();
+  });
+
+  test('E2E-BUNQ-CONFIG-006 global admin cancels Update API Key form', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Bunq Config Cancel Update Admin', true);
+    await devLoginAs(page, admin);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.getByRole('button', { name: 'Update API Key' }).click();
+    await expect(page.getByRole('heading', { name: 'Specify Bunq API Credentials' })).toBeVisible();
+    await page.getByRole('button', { name: 'Cancel' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Specify Bunq API Credentials' })).toHaveCount(0);
+    await expect(page.getByText(/Bunq integration is enabled/)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Disable Integration' })).toBeVisible();
+  });
+
+  test('E2E-BUNQ-CONFIG-007 global admin disables Bunq integration after confirm', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Bunq Config Disable Admin', true);
+    await devLoginAs(page, admin);
+    await enableBunqIntegrationViaUi(page);
+
+    await disableBunqIntegrationViaUi(page, true);
+
+    await expect(page.getByText(/Bunq integration disabled successfully/i)).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(/Bunq integration is disabled/)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Enable Bunq Integration' })).toBeVisible();
+  });
+
+  test('E2E-BUNQ-CONFIG-008 global admin cancels disable and integration stays enabled', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Bunq Config Cancel Disable Admin', true);
+    await devLoginAs(page, admin);
+    await enableBunqIntegrationViaUi(page);
+
+    await disableBunqIntegrationViaUi(page, false);
+
+    await expect(page.getByText(/Bunq integration disabled successfully/i)).toHaveCount(0);
+    await expect(page.getByText(/Bunq integration is enabled/)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Disable Integration' })).toBeVisible();
+  });
+
+  test('E2E-BUNQ-CONFIG-009 global admin enables Bunq for assigned administrator', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Bunq Config Assign Global', true);
+    const assigned = await createDevUserViaApi(request, testInfo, 'Bunq Config Assign Target');
+    await devLoginAs(page, admin);
+    await createAdminAssignmentForUser(page, assigned.displayName);
+
+    const assignmentRow = page.locator('.administrator-item').filter({ hasText: assigned.displayName });
+    await assignmentRow.getByTitle('Configure Bunq Settings').click();
+    await waitForBunqSettingsReady(page, new RegExp(`Bunq Settings \\(${assigned.displayName}\\)`));
+
+    await openBunqCredentialsForm(page);
+    await fillBunqCredentialsForm(page, {
+      apiKey: BUNQ_E2E_API_KEY,
+      apiKeyName: BUNQ_E2E_API_KEY_NAME,
+      password: BUNQ_E2E_PASSWORD,
+    });
+    await submitBunqCredentialsForm(page);
+
+    await expect(page.getByText(/Bunq integration enabled successfully/i)).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByText(/Bunq integration is enabled/)).toBeVisible();
+  });
+
+  test('E2E-BUNQ-CONFIG-010 participant cannot manage Bunq settings', async ({ page, request }, testInfo) => {
+    const participant = await createDevUserViaApi(request, testInfo, 'Bunq Config Participant');
+    await devLoginAs(page, participant);
+
+    await page.goto('/bunq-settings');
+    await waitForBunqSettingsReady(page);
+
+    await expect(page.getByText(/Failed to load Bunq integration status/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Enable Bunq Integration' })).toBeVisible();
+    await expect(page.getByText(/Bunq integration is disabled/)).toBeVisible();
+
+    await openBunqCredentialsForm(page);
+    await fillBunqCredentialsForm(page, {
+      apiKey: BUNQ_E2E_API_KEY,
+      apiKeyName: BUNQ_E2E_API_KEY_NAME,
+      password: BUNQ_E2E_PASSWORD,
+    });
+    const enableResponsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' && new URL(response.url()).pathname === '/api/users/me/bunq/enable'
+    );
+    await submitBunqCredentialsForm(page);
+    const enableResponse = await enableResponsePromise;
+    expect(enableResponse.status()).toBe(403);
+    await expect(page.getByText(/Bunq integration is enabled/i)).toHaveCount(0);
+  });
+
+  test('E2E-BUNQ-CONFIG-011 wrong Bunq password shows inline errors on account load and webhook install', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Bunq Config Wrong Pass Admin', true);
+    await devLoginAs(page, admin);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.reload();
+    await waitForBunqSettingsReady(page);
+
+    await loadMonetaryAccountsViaUi(page, 'WrongPassword!9');
+    await expect(page.locator('.bunq-settings-container .error-message')).toContainText(/Failed to load Bunq accounts/i);
+    await expect(page.locator('#monetaryAccount')).toHaveCount(0);
+
+    await page.reload();
+    await waitForBunqSettingsReady(page);
+    await expect(page.getByText(/Bunq integration is enabled/)).toBeVisible();
+
+    await installBunqWebhookViaUi(page, 'WrongPassword!9');
+    await expect(page.locator('.password-dialog-overlay')).toBeVisible();
+    await expect(page.locator('.password-dialog-overlay .error-message')).toContainText(/Failed to install webhook/i);
+    await expect(page.getByText(/Webhook installed successfully/i)).toHaveCount(0);
+  });
+});

--- a/e2e/bunq-pay.spec.ts
+++ b/e2e/bunq-pay.spec.ts
@@ -1,0 +1,232 @@
+import { expect, test } from '@playwright/test';
+import {
+  addParticipantViaUi,
+  BUNQ_E2E_PASSWORD,
+  cleanupE2eData,
+  createDevUserViaApi,
+  createGameViaUi,
+  daysFromNow,
+  devLoginAs,
+  dismissPaymentRequestsSentDialog,
+  enableBunqIntegrationForUserViaUi,
+  enableBunqIntegrationViaUi,
+  e2eTitle,
+  moveGameToPastViaUi,
+  resetBunqMock,
+  sendPaymentRequestsViaUi,
+  submitSendPaymentRequestsPassword,
+  switchToUser,
+  updateGame,
+  waitForBackend,
+} from './support/fixtures';
+
+function assignmentDayOptionForDate(date: Date) {
+  const jsDay = date.getDay();
+  return String(jsDay === 0 ? 6 : jsDay - 1);
+}
+
+async function createAssignmentForDate(
+  page: import('@playwright/test').Page,
+  assigneeDisplayName: string,
+  gameDate: Date
+) {
+  await page.goto('/game-administrators');
+  await expect(page.getByRole('heading', { name: 'Game Administrators' })).toBeVisible();
+  await page.getByRole('button', { name: 'Add Assignment' }).click();
+  await page.getByLabel('Day of Week').selectOption(assignmentDayOptionForDate(gameDate));
+  await page.getByRole('checkbox', { name: /5-1 positions game/i }).uncheck();
+  await page.getByPlaceholder('Search for a user...').fill(assigneeDisplayName);
+  await page.getByText(assigneeDisplayName, { exact: true }).click();
+  await page.getByRole('button', { name: 'Create' }).click();
+}
+
+test.describe('Bunq payment request scenarios', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await resetBunqMock();
+    await cleanupE2eData();
+  });
+
+  test('E2E-BUNQ-PAY-001 send control on past paid game only', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Pay Visibility Admin', true);
+    const title = e2eTitle(testInfo, 'Pay Visibility');
+    await devLoginAs(page, admin);
+
+    const pastGame = await createGameViaUi(page, {
+      title: `${title} Past`,
+      dateTime: daysFromNow(2),
+    });
+    const upcomingGame = await createGameViaUi(page, {
+      title: `${title} Upcoming`,
+      dateTime: daysFromNow(3),
+    });
+
+    await moveGameToPastViaUi(page, pastGame.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${pastGame.id}`);
+    await expect(page.getByTitle('Send payment requests to unpaid players')).toBeVisible();
+
+    await page.goto(`/game/${upcomingGame.id}`);
+    await expect(page.getByTitle('Send payment requests to unpaid players')).toHaveCount(0);
+  });
+
+  test('E2E-BUNQ-PAY-002 send payment requests locks roster and shows collector', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Pay Send Admin', true);
+    const participantA = await createDevUserViaApi(request, testInfo, 'Pay Send A');
+    const participantB = await createDevUserViaApi(request, testInfo, 'Pay Send B');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Pay Send Game'),
+      dateTime: daysFromNow(2),
+    });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participantA.displayName);
+    await expect(page.getByTitle('Add Participant')).toBeVisible();
+    await addParticipantViaUi(page, participantB.displayName);
+
+    await sendPaymentRequestsViaUi(page);
+
+    await expect(page.getByText('Payments collected by')).toBeVisible();
+    await expect(page.locator('.collector-name')).toContainText(admin.displayName);
+    await expect(page.getByTitle('Add Participant')).toHaveCount(0);
+    await expect(page.locator('.player-item').filter({ hasText: participantA.displayName }).getByText('Unpaid')).toBeVisible();
+    await expect(page.locator('.player-item').filter({ hasText: participantB.displayName }).getByText('Unpaid')).toBeVisible();
+    await expect(
+      page.locator('.player-item').filter({ hasText: participantB.displayName }).getByRole('button', { name: 'Remove player' })
+    ).toHaveCount(0);
+  });
+
+  test('E2E-BUNQ-PAY-003 second send reports zero new payment requests', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Pay Second Send Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Pay Second Send Player');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Pay Second Send'),
+      dateTime: daysFromNow(2),
+    });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+    await sendPaymentRequestsViaUi(page);
+
+    await page.reload();
+    await expect(page.getByText('Payments collected by')).toBeVisible();
+    await submitSendPaymentRequestsPassword(page, BUNQ_E2E_PASSWORD);
+    await dismissPaymentRequestsSentDialog(page, 0);
+  });
+
+  test('E2E-BUNQ-PAY-004 invalid password on send keeps dialog open', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Pay Wrong Pass Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Pay Wrong Pass Player');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Pay Wrong Pass'),
+      dateTime: daysFromNow(2),
+    });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+
+    await submitSendPaymentRequestsPassword(page, 'WrongPassword!9');
+    await expect(page.locator('.password-dialog-overlay')).toBeVisible();
+    await expect(page.locator('.password-dialog-overlay')).toContainText('Invalid password');
+    await expect(page.getByRole('dialog').filter({ hasText: 'Payment requests sent' })).toHaveCount(0);
+  });
+
+  test('E2E-BUNQ-PAY-005 assigned admin can send payment requests participant cannot', async ({ page, request }, testInfo) => {
+    const globalAdmin = await createDevUserViaApi(request, testInfo, 'Pay Assigned Global', true);
+    const assignedAdmin = await createDevUserViaApi(request, testInfo, 'Pay Assigned Admin');
+    const participant = await createDevUserViaApi(request, testInfo, 'Pay Assigned Participant');
+
+    await devLoginAs(page, globalAdmin);
+    const pastGameDate = daysFromNow(-3);
+    await createAssignmentForDate(page, assignedAdmin.displayName, pastGameDate);
+    await enableBunqIntegrationForUserViaUi(page, assignedAdmin.id);
+
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Pay Assigned Game'),
+      dateTime: pastGameDate,
+    });
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+
+    await switchToUser(page, assignedAdmin);
+    await page.goto(`/game/${game.id}`);
+    await sendPaymentRequestsViaUi(page);
+    await expect(page.getByText('Payments collected by')).toBeVisible();
+
+    await switchToUser(page, participant);
+    await page.goto(`/game/${game.id}`);
+    await expect(page.getByTitle('Send payment requests to unpaid players')).toHaveCount(0);
+    await expect(page.getByTitle('Check payment status for this game')).toHaveCount(0);
+    await expect(page.getByTitle('Edit Game Settings')).toHaveCount(0);
+  });
+
+  test('E2E-BUNQ-PAY-006 readonly past game supports send payment requests', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Pay Readonly Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Pay Readonly Player');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Pay Readonly Past'),
+      dateTime: daysFromNow(2),
+      readonly: true,
+    });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+    await expect(page.getByTitle('Send payment requests to unpaid players')).toBeVisible();
+    await sendPaymentRequestsViaUi(page);
+    await expect(page.getByText('Payments collected by')).toBeVisible();
+  });
+
+  test('E2E-BUNQ-PAY-007 zero-cost past game hides send payment requests', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Pay Zero Cost Admin', true);
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Pay Zero Cost'),
+      dateTime: daysFromNow(2),
+      paymentAmount: '0',
+    });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await expect(page.getByTitle('Send payment requests to unpaid players')).toHaveCount(0);
+  });
+
+  test('E2E-BUNQ-PAY-008 fully paid past game hides send payment requests', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Pay Fully Paid Admin', true);
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Pay Fully Paid'),
+      dateTime: daysFromNow(-1),
+    });
+
+    await updateGame(game.id, { fully_paid: true });
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await expect(page.getByTitle('Send payment requests to unpaid players')).toHaveCount(0);
+  });
+});

--- a/e2e/bunq-pay.spec.ts
+++ b/e2e/bunq-pay.spec.ts
@@ -11,12 +11,12 @@ import {
   enableBunqIntegrationForUserViaUi,
   enableBunqIntegrationViaUi,
   e2eTitle,
+  markGameFullyPaidViaBunq,
   moveGameToPastViaUi,
   resetBunqMock,
   sendPaymentRequestsViaUi,
   submitSendPaymentRequestsPassword,
   switchToUser,
-  updateGame,
   waitForBackend,
 } from './support/fixtures';
 
@@ -216,17 +216,20 @@ test.describe('Bunq payment request scenarios', () => {
 
   test('E2E-BUNQ-PAY-008 fully paid past game hides send payment requests', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Pay Fully Paid Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Pay Fully Paid Player');
 
     await devLoginAs(page, admin);
     const game = await createGameViaUi(page, {
       title: e2eTitle(testInfo, 'Pay Fully Paid'),
-      dateTime: daysFromNow(-1),
+      dateTime: daysFromNow(2),
     });
 
-    await updateGame(game.id, { fully_paid: true });
+    await moveGameToPastViaUi(page, game.id);
     await enableBunqIntegrationViaUi(page);
-
     await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+    await markGameFullyPaidViaBunq(page, game.id, [participant.id]);
+
     await expect(page.getByTitle('Send payment requests to unpaid players')).toHaveCount(0);
   });
 });

--- a/e2e/bunq-status.spec.ts
+++ b/e2e/bunq-status.spec.ts
@@ -1,0 +1,227 @@
+import { expect, test } from '@playwright/test';
+import {
+  addParticipantViaUi,
+  BUNQ_E2E_PASSWORD,
+  cleanupE2eData,
+  createDevUserViaApi,
+  createGameViaUi,
+  daysFromNow,
+  devLoginAs,
+  dismissPaymentCheckCompletedDialog,
+  enableBunqIntegrationViaUi,
+  e2eTitle,
+  getPaymentRequestIdForUserRegistration,
+  markBunqRequestInquiryAccepted,
+  moveGameToPastViaUi,
+  registerForGameViaUi,
+  resetBunqMock,
+  sendPaymentRequestsViaUi,
+  submitCheckPaymentStatusForGame,
+  switchToUser,
+  togglePlayerPaidStatusViaUi,
+  waitForBackend,
+} from './support/fixtures';
+
+test.describe('Bunq payment status scenarios', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await resetBunqMock();
+    await cleanupE2eData();
+  });
+
+  test('E2E-BUNQ-STATUS-002 per-game check marks unpaid players paid when mock reports ACCEPTED', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Status Check Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Status Check Player');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Status Check Game'),
+      dateTime: daysFromNow(2),
+    });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+    await sendPaymentRequestsViaUi(page);
+
+    const inquiryId = await getPaymentRequestIdForUserRegistration(game.id, participant.id);
+    expect(inquiryId).toBeTruthy();
+    await markBunqRequestInquiryAccepted(inquiryId!);
+
+    await submitCheckPaymentStatusForGame(page);
+    await dismissPaymentCheckCompletedDialog(page);
+
+    const row = page.locator('.player-item').filter({ hasText: participant.displayName });
+    await expect(row.getByText('Paid')).toBeVisible();
+  });
+
+  test('E2E-BUNQ-STATUS-003 admin toggles paid status and past list counts update', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Status Toggle Admin', true);
+    const playerA = await createDevUserViaApi(request, testInfo, 'Status Toggle A');
+    const playerB = await createDevUserViaApi(request, testInfo, 'Status Toggle B');
+    const title = e2eTitle(testInfo, 'Status Toggle Game');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title, dateTime: daysFromNow(2) });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, playerA.displayName);
+    await addParticipantViaUi(page, playerB.displayName);
+    await sendPaymentRequestsViaUi(page);
+
+    await togglePlayerPaidStatusViaUi(page, playerA.displayName);
+    await togglePlayerPaidStatusViaUi(page, playerB.displayName);
+
+    await page.goto('/');
+    await page.getByLabel('Past').check();
+    await page.getByLabel('Show fully paid games').check();
+    const card = page.locator('.game-card-wrapper').filter({ hasText: title });
+    await expect(card).toBeVisible();
+    await expect(card.locator('.compact-stats .counter').nth(0)).toHaveText('2');
+    await expect(card.locator('.compact-stats .counter').nth(1)).toHaveText('2');
+
+    await page.goto(`/game/${game.id}`);
+    await togglePlayerPaidStatusViaUi(page, playerA.displayName);
+
+    await page.goto('/');
+    await page.getByLabel('Past').check();
+    await page.getByLabel('Show fully paid games').check();
+    await expect(card.locator('.compact-stats .counter').nth(0)).toHaveText('1');
+    await expect(card.locator('.compact-stats .counter').nth(1)).toHaveText('2');
+  });
+
+  test('E2E-BUNQ-STATUS-004 fully paid past game shows counts and hides until toggle', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Status Fully Paid Admin', true);
+    const playerA = await createDevUserViaApi(request, testInfo, 'Status Fully Paid A');
+    const playerB = await createDevUserViaApi(request, testInfo, 'Status Fully Paid B');
+    const title = e2eTitle(testInfo, 'Status Fully Paid Game');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title, dateTime: daysFromNow(2), maxPlayers: 12 });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, playerA.displayName);
+    await addParticipantViaUi(page, playerB.displayName);
+    await sendPaymentRequestsViaUi(page);
+    await togglePlayerPaidStatusViaUi(page, playerA.displayName);
+    await togglePlayerPaidStatusViaUi(page, playerB.displayName);
+
+    await page.goto('/');
+    await page.getByLabel('Past').check();
+    await page.getByLabel('Show fully paid games').check();
+    const card = page.locator('.game-card-wrapper').filter({ hasText: title });
+    await expect(card).toBeVisible();
+    await expect(card.locator('.compact-stats .counter').nth(0)).toHaveText('2');
+    await expect(card.locator('.compact-stats .counter').nth(1)).toHaveText('2');
+
+    await page.getByLabel('Show fully paid games').uncheck();
+    await expect(page.getByText(title)).toHaveCount(0);
+    await page.getByLabel('Show fully paid games').check();
+    await expect(page.getByText(title)).toBeVisible();
+    await expect(card.locator('.compact-stats .counter').nth(0)).toHaveText('2');
+  });
+
+  test('E2E-BUNQ-STATUS-005 wrong password on per-game check keeps dialog open', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Status Wrong Pass Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Status Wrong Pass Player');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Status Wrong Pass'),
+      dateTime: daysFromNow(2),
+    });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+    await sendPaymentRequestsViaUi(page);
+
+    await submitCheckPaymentStatusForGame(page, 'WrongPassword!9');
+    await expect(page.locator('.password-dialog-overlay')).toBeVisible();
+    await expect(page.locator('.password-dialog-overlay')).toContainText('Invalid password');
+    await expect(page.locator('.dialog-overlay').filter({ hasText: 'Payment check completed' })).toHaveCount(0);
+  });
+
+  test('E2E-BUNQ-STATUS-006 bulk check-payments route updates unpaid past games', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Status Bulk Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Status Bulk Player');
+    const title = e2eTitle(testInfo, 'Status Bulk Game');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title, dateTime: daysFromNow(2) });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+    await sendPaymentRequestsViaUi(page);
+
+    const inquiryId = await getPaymentRequestIdForUserRegistration(game.id, participant.id);
+    expect(inquiryId).toBeTruthy();
+    await markBunqRequestInquiryAccepted(inquiryId!);
+
+    page.once('dialog', async (dialog) => {
+      expect(dialog.type()).toBe('alert');
+      expect(dialog.message()).toMatch(/Payment check completed/i);
+      await dialog.accept();
+    });
+
+    await page.goto('/check-payments');
+    await expect(page.getByRole('heading', { name: 'Enter Bunq API Password' })).toBeVisible();
+    await page.locator('.password-dialog-overlay').getByLabel('Password:').fill(BUNQ_E2E_PASSWORD);
+    await page.locator('.password-dialog-overlay').getByRole('button', { name: 'Submit' }).click();
+
+    await expect(page).toHaveURL('/', { timeout: 60_000 });
+    await page.getByLabel('Past').check();
+    await page.goto(`/game/${game.id}`);
+    const row = page.locator('.player-item').filter({ hasText: participant.displayName });
+    await expect(row.getByText('Paid')).toBeVisible();
+  });
+
+  test('E2E-BUNQ-STATUS-007 participant does not see admin payment controls on past game', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Status Participant Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Status Participant View');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Status Participant Game'),
+      dateTime: daysFromNow(2),
+      paymentAmount: '7.50',
+    });
+
+    await registerForGameViaUi(page, participant, game.id);
+
+    await switchToUser(page, admin);
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await sendPaymentRequestsViaUi(page);
+
+    await switchToUser(page, participant);
+    await page.goto(`/game/${game.id}`);
+
+    await expect(page.getByText('€7.50')).toBeVisible();
+    await expect(page.getByText("You're in", { exact: true })).toBeVisible();
+    await expect(page.getByTitle('Check payment status for this game')).toHaveCount(0);
+    await expect(page.getByTitle('Send payment requests to unpaid players')).toHaveCount(0);
+    await expect(page.locator('.paid-status')).toHaveCount(0);
+  });
+});

--- a/e2e/bunq-webhook.spec.ts
+++ b/e2e/bunq-webhook.spec.ts
@@ -6,16 +6,15 @@ import {
   daysFromNow,
   deliverBunqRequestInquiryAcceptedWebhook,
   devLoginAs,
+  enableBunqIntegrationViaUi,
   e2eTitle,
-  formatGameDateTimeForInput,
   getPaymentRequestIdForUserRegistration,
+  moveGameToPastViaUi,
   registerForGameViaUi,
   resetBunqMock,
-  waitForAdminGameUpdateResponse,
+  sendPaymentRequestsViaUi,
   waitForBackend,
 } from './support/fixtures';
-
-const BUNQ_E2E_PASSWORD = 'BunqE2E!Pass9';
 
 test.describe('Bunq mock and webhook-driven payments', () => {
   test.beforeEach(async ({ request }) => {
@@ -44,35 +43,10 @@ test.describe('Bunq mock and webhook-driven payments', () => {
       await devLoginAs(participantPage, participant);
       await registerForGameViaUi(participantPage, participant, game.id);
 
-      await adminPage.goto(`/game/${game.id}/edit`);
-      await expect(adminPage.getByRole('heading', { name: 'Edit Game Settings' })).toBeVisible();
-      const pastDate = daysFromNow(-2);
-      const dateInput = adminPage.getByPlaceholder('Select date and time');
-      await dateInput.fill(formatGameDateTimeForInput(pastDate));
-      await dateInput.press('Enter');
-      const updatePromise = waitForAdminGameUpdateResponse(adminPage, game.id);
-      await adminPage.getByRole('button', { name: 'Save Changes' }).click();
-      await updatePromise;
-      await expect(adminPage).toHaveURL(new RegExp(`/game/${game.id}$`));
-
-      await adminPage.goto('/bunq-settings');
-      await expect(adminPage.getByRole('heading', { name: 'Bunq Settings' })).toBeVisible();
-      await adminPage.getByRole('button', { name: 'Enable Bunq Integration' }).click();
-      await adminPage.locator('#apiKey').fill('e2e-bunq-api-key');
-      await adminPage.locator('#apiKeyName').fill('E2E Bunq Client');
-      await adminPage.locator('.credentials-form #password').fill(BUNQ_E2E_PASSWORD);
-      await adminPage.getByRole('button', { name: 'Enable Integration' }).click();
-      await expect(adminPage.getByText('Bunq integration enabled successfully')).toBeVisible({ timeout: 60_000 });
-
+      await moveGameToPastViaUi(adminPage, game.id);
+      await enableBunqIntegrationViaUi(adminPage);
       await adminPage.goto(`/game/${game.id}`);
-      const sendBtn = adminPage.getByTitle('Send payment requests to unpaid players');
-      await expect(sendBtn).toBeVisible({ timeout: 30_000 });
-      await sendBtn.click();
-      await adminPage.locator('.password-dialog-overlay').getByLabel('Password:').fill(BUNQ_E2E_PASSWORD);
-      await adminPage.locator('.password-dialog-overlay').getByRole('button', { name: 'Submit' }).click();
-      const paymentSentDialog = adminPage.getByRole('dialog').filter({ hasText: 'Payment requests sent' });
-      await expect(paymentSentDialog.getByText(/payment requests sent successfully/i)).toBeVisible({ timeout: 60_000 });
-      await paymentSentDialog.getByRole('button', { name: 'OK' }).click();
+      await sendPaymentRequestsViaUi(adminPage);
 
       const inquiryId = await getPaymentRequestIdForUserRegistration(game.id, participant.id);
       expect(inquiryId).toBeTruthy();

--- a/e2e/bunq-webhook.spec.ts
+++ b/e2e/bunq-webhook.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test';
+import {
+  cleanupE2eData,
+  createDevUserViaApi,
+  createGameViaUi,
+  daysFromNow,
+  deliverBunqRequestInquiryAcceptedWebhook,
+  devLoginAs,
+  e2eTitle,
+  getPaymentRequestIdForUserRegistration,
+  registerForGameViaUi,
+  resetBunqMock,
+  updateGame,
+  waitForBackend,
+} from './support/fixtures';
+
+const BUNQ_E2E_PASSWORD = 'BunqE2E!Pass9';
+
+test.describe('Bunq mock and webhook-driven payments', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await resetBunqMock();
+    await cleanupE2eData();
+  });
+
+  test('E2E-BUNQ-001 Bunq mock webhook marks player paid after admin sends payment requests', async ({ browser, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Bunq Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Bunq Participant');
+
+    const adminContext = await browser.newContext();
+    const participantContext = await browser.newContext();
+
+    try {
+      const adminPage = await adminContext.newPage();
+      const participantPage = await participantContext.newPage();
+
+      await devLoginAs(adminPage, admin);
+      const game = await createGameViaUi(adminPage, {
+        title: e2eTitle(testInfo, 'Bunq Webhook Game'),
+        dateTime: daysFromNow(2),
+      });
+
+      await devLoginAs(participantPage, participant);
+      await registerForGameViaUi(participantPage, participant, game.id);
+
+      await updateGame(game.id, { date_time: daysFromNow(-2) });
+
+      await adminPage.goto('/bunq-settings');
+      await expect(adminPage.getByRole('heading', { name: 'Bunq Settings' })).toBeVisible();
+      await adminPage.getByRole('button', { name: 'Enable Bunq Integration' }).click();
+      await adminPage.locator('#apiKey').fill('e2e-bunq-api-key');
+      await adminPage.locator('#apiKeyName').fill('E2E Bunq Client');
+      await adminPage.locator('.credentials-form #password').fill(BUNQ_E2E_PASSWORD);
+      await adminPage.getByRole('button', { name: 'Enable Integration' }).click();
+      await expect(adminPage.getByText('Bunq integration enabled successfully')).toBeVisible({ timeout: 60_000 });
+
+      await adminPage.goto(`/game/${game.id}`);
+      const sendBtn = adminPage.getByTitle('Send payment requests to unpaid players');
+      await expect(sendBtn).toBeVisible({ timeout: 30_000 });
+      await sendBtn.click();
+      await adminPage.locator('.password-dialog-overlay').getByLabel('Password:').fill(BUNQ_E2E_PASSWORD);
+      await adminPage.locator('.password-dialog-overlay').getByRole('button', { name: 'Submit' }).click();
+      const paymentSentDialog = adminPage.getByRole('dialog').filter({ hasText: 'Payment requests sent' });
+      await expect(paymentSentDialog.getByText(/payment requests sent successfully/i)).toBeVisible({ timeout: 60_000 });
+      await paymentSentDialog.getByRole('button', { name: 'OK' }).click();
+
+      const inquiryId = await getPaymentRequestIdForUserRegistration(game.id, participant.id);
+      expect(inquiryId).toBeTruthy();
+      await deliverBunqRequestInquiryAcceptedWebhook(inquiryId!);
+
+      await adminPage.reload();
+      const row = adminPage.locator('.player-item').filter({ hasText: participant.displayName });
+      await expect(row.getByText('Paid')).toBeVisible();
+    } finally {
+      await adminContext.close();
+      await participantContext.close();
+    }
+  });
+});

--- a/e2e/bunq-webhook.spec.ts
+++ b/e2e/bunq-webhook.spec.ts
@@ -7,10 +7,11 @@ import {
   deliverBunqRequestInquiryAcceptedWebhook,
   devLoginAs,
   e2eTitle,
+  formatGameDateTimeForInput,
   getPaymentRequestIdForUserRegistration,
   registerForGameViaUi,
   resetBunqMock,
-  updateGame,
+  waitForAdminGameUpdateResponse,
   waitForBackend,
 } from './support/fixtures';
 
@@ -43,7 +44,16 @@ test.describe('Bunq mock and webhook-driven payments', () => {
       await devLoginAs(participantPage, participant);
       await registerForGameViaUi(participantPage, participant, game.id);
 
-      await updateGame(game.id, { date_time: daysFromNow(-2) });
+      await adminPage.goto(`/game/${game.id}/edit`);
+      await expect(adminPage.getByRole('heading', { name: 'Edit Game Settings' })).toBeVisible();
+      const pastDate = daysFromNow(-2);
+      const dateInput = adminPage.getByPlaceholder('Select date and time');
+      await dateInput.fill(formatGameDateTimeForInput(pastDate));
+      await dateInput.press('Enter');
+      const updatePromise = waitForAdminGameUpdateResponse(adminPage, game.id);
+      await adminPage.getByRole('button', { name: 'Save Changes' }).click();
+      await updatePromise;
+      await expect(adminPage).toHaveURL(new RegExp(`/game/${game.id}$`));
 
       await adminPage.goto('/bunq-settings');
       await expect(adminPage.getByRole('heading', { name: 'Bunq Settings' })).toBeVisible();

--- a/e2e/cross-user-state.spec.ts
+++ b/e2e/cross-user-state.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test } from '@playwright/test';
+import {
+  cleanupE2eData,
+  createDevUserViaApi,
+  createGame,
+  createGameViaUi,
+  daysFromNow,
+  devLoginAs,
+  e2eTitle,
+  nextWeekday,
+  registerUser,
+  switchToUser,
+  waitForBackend,
+} from './support/fixtures';
+
+async function joinGameWithoutBall(page: import('@playwright/test').Page, expectedStatus = "You're in") {
+  await page.getByRole('button', { name: 'Join Game' }).click();
+  await expect(page.getByRole('heading', { name: 'Will you bring a volleyball?' })).toBeVisible();
+  await page.getByRole('button', { name: /No, I won't bring one/ }).click();
+  await expect(page.getByText(expectedStatus, { exact: true })).toBeVisible();
+}
+
+test.describe('cross-user and state-transition scenarios', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await cleanupE2eData();
+  });
+
+  test('E2E-STATE-001 admin sees participant in players list after refresh in another context', async ({ browser, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'State1 Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'State1 Participant');
+    const adminContext = await browser.newContext();
+    const participantContext = await browser.newContext();
+
+    try {
+      const adminPage = await adminContext.newPage();
+      const participantPage = await participantContext.newPage();
+
+      await devLoginAs(adminPage, admin);
+      const game = await createGameViaUi(adminPage, {
+        title: e2eTitle(testInfo, 'State Cross Game'),
+        dateTime: nextWeekday(0),
+      });
+
+      await devLoginAs(participantPage, participant);
+      await participantPage.goto(`/game/${game.id}`);
+      await joinGameWithoutBall(participantPage);
+
+      await adminPage.goto(`/game/${game.id}`);
+      await expect(adminPage.getByText(participant.displayName)).toHaveCount(0);
+      await adminPage.reload();
+      await expect(adminPage.getByText(participant.displayName)).toBeVisible();
+    } finally {
+      await adminContext.close();
+      await participantContext.close();
+    }
+  });
+
+  test('E2E-STATE-002 last spot goes to first joiner and second joiner is waitlisted', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'State2 Admin', true);
+    const preRegistered = await createDevUserViaApi(request, testInfo, 'State2 PreRegistered');
+    const first = await createDevUserViaApi(request, testInfo, 'State2 First');
+    const second = await createDevUserViaApi(request, testInfo, 'State2 Second');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Almost Full'),
+      dateTime: daysFromNow(2),
+      maxPlayers: 2,
+    });
+    await registerUser(game.id, preRegistered.id, new Date(Date.now() - 60_000));
+
+    await switchToUser(page, first);
+    await page.goto(`/game/${game.id}`);
+    await joinGameWithoutBall(page);
+
+    await switchToUser(page, second);
+    await page.goto(`/game/${game.id}`);
+    await joinGameWithoutBall(page, 'Waitlist');
+
+    await expect(page.getByRole('heading', { name: 'Waiting List' })).toBeVisible();
+  });
+
+  test('E2E-STATE-003 reducing capacity preserves active and waitlist sections', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'State3 Admin', true);
+    const players = await Promise.all(
+      [0, 1, 2, 3, 4].map((i) => createDevUserViaApi(request, testInfo, `State3 P${i}`))
+    );
+    const title = e2eTitle(testInfo, 'Capacity Shrink');
+    const game = await createGame({
+      title,
+      createdById: admin.id,
+      dateTime: daysFromNow(2),
+      maxPlayers: 4,
+    });
+    const base = Date.now();
+    for (let i = 0; i < 5; i++) {
+      await registerUser(game.id, players[i].id, new Date(base + i * 1000));
+    }
+
+    await devLoginAs(page, admin);
+    await page.goto(`/game/${game.id}/edit`);
+    await expect(page.getByRole('heading', { name: 'Edit Game Settings' })).toBeVisible();
+    await page.locator('#maxPlayers').fill('2');
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+    await expect(page).toHaveURL(new RegExp(`/game/${game.id}$`));
+
+    await expect(page.locator('.registered-count')).toHaveText('2');
+    await expect(page.locator('.max-count')).toHaveText('2');
+    await expect(page.locator('.waitlist-indicator')).toHaveText('(+3)');
+    await expect(page.locator('.players-section:not(.waitlist-section) .player-item')).toHaveCount(2);
+    await expect(page.locator('.waitlist-section .player-item')).toHaveCount(3);
+  });
+
+  test('E2E-STATE-004 browser refresh keeps authenticated session and route', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'State4 Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'State4 Participant');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'State4 Game'),
+      dateTime: nextWeekday(0),
+    });
+
+    await switchToUser(page, participant);
+    await page.goto(`/game/${game.id}`);
+    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible();
+
+    await page.reload();
+
+    await expect(page).toHaveURL(new RegExp(`/game/${game.id}$`));
+    await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible();
+    await expect(page.getByText(game.title)).toBeVisible();
+  });
+
+  test('E2E-STATE-005 fresh browser context starts unauthenticated', async ({ browser }) => {
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
+      await page.goto('/');
+
+      await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Logout' })).toHaveCount(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/e2e/cross-user-state.spec.ts
+++ b/e2e/cross-user-state.spec.ts
@@ -2,14 +2,14 @@ import { expect, test } from '@playwright/test';
 import {
   cleanupE2eData,
   createDevUserViaApi,
-  createGame,
   createGameViaUi,
   daysFromNow,
   devLoginAs,
   e2eTitle,
   nextWeekday,
-  registerUser,
+  registerForGameViaUi,
   switchToUser,
+  type DevUser,
   waitForBackend,
 } from './support/fixtures';
 
@@ -67,37 +67,32 @@ test.describe('cross-user and state-transition scenarios', () => {
       dateTime: daysFromNow(2),
       maxPlayers: 2,
     });
-    await registerUser(game.id, preRegistered.id, new Date(Date.now() - 60_000));
-
-    await switchToUser(page, first);
-    await page.goto(`/game/${game.id}`);
-    await joinGameWithoutBall(page);
-
-    await switchToUser(page, second);
-    await page.goto(`/game/${game.id}`);
-    await joinGameWithoutBall(page, 'Waitlist');
+    await registerForGameViaUi(page, preRegistered, game.id);
+    await registerForGameViaUi(page, first, game.id);
+    await registerForGameViaUi(page, second, game.id, 'Waitlist');
 
     await expect(page.getByRole('heading', { name: 'Waiting List' })).toBeVisible();
   });
 
   test('E2E-STATE-003 reducing capacity preserves active and waitlist sections', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'State3 Admin', true);
-    const players = await Promise.all(
-      [0, 1, 2, 3, 4].map((i) => createDevUserViaApi(request, testInfo, `State3 P${i}`))
-    );
+    const players: DevUser[] = [];
+    for (let i = 0; i < 5; i++) {
+      players.push(await createDevUserViaApi(request, testInfo, `State3 P${i}`));
+    }
     const title = e2eTitle(testInfo, 'Capacity Shrink');
-    const game = await createGame({
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
       title,
-      createdById: admin.id,
       dateTime: daysFromNow(2),
       maxPlayers: 4,
     });
-    const base = Date.now();
-    for (let i = 0; i < 5; i++) {
-      await registerUser(game.id, players[i].id, new Date(base + i * 1000));
+    for (let i = 0; i < 4; i++) {
+      await registerForGameViaUi(page, players[i], game.id);
     }
+    await registerForGameViaUi(page, players[4], game.id, 'Waitlist');
 
-    await devLoginAs(page, admin);
+    await switchToUser(page, admin);
     await page.goto(`/game/${game.id}/edit`);
     await expect(page.getByRole('heading', { name: 'Edit Game Settings' })).toBeVisible();
     await page.locator('#maxPlayers').fill('2');

--- a/e2e/game-administration.spec.ts
+++ b/e2e/game-administration.spec.ts
@@ -1,0 +1,195 @@
+import { expect, test } from '@playwright/test';
+import {
+  cleanupE2eData,
+  countRegistrations,
+  createAdminAssignment,
+  createDevUserViaApi,
+  createGame,
+  daysFromNow,
+  devLogin,
+  devLoginAs,
+  e2eTitle,
+  findGameById,
+  nextWeekday,
+  registerUser,
+  waitForBackend,
+} from './support/fixtures';
+
+async function confirmDialog(page: import('@playwright/test').Page, confirm = true) {
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await page.getByRole('dialog').getByRole('button', { name: confirm ? 'OK' : 'Cancel' }).click();
+}
+
+async function removePlayerByName(page: import('@playwright/test').Page, displayName: string) {
+  const row = page.locator('.player-item').filter({ hasText: displayName }).first();
+  await row.getByRole('button', { name: 'Remove player' }).click();
+  await confirmDialog(page, true);
+}
+
+test.describe('game administration scenarios', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await cleanupE2eData();
+  });
+
+  test('E2E-ADMIN-001 global admin deletes an upcoming game after confirming', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Delete Admin', true);
+    const game = await createGame({ title: e2eTitle(testInfo, 'Delete Upcoming'), createdById: admin.id, dateTime: daysFromNow(2) });
+
+    await devLoginAs(page, admin);
+    await page.goto(`/game/${game.id}`);
+    await page.getByTitle('Delete Game').click();
+    await confirmDialog(page, true);
+
+    await expect(page).toHaveURL('/');
+    expect(await findGameById(game.id)).toBeNull();
+  });
+
+  test('E2E-ADMIN-002 global admin cancels delete and game remains available', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Cancel Delete Admin', true);
+    const title = e2eTitle(testInfo, 'Cancel Delete Game');
+    const game = await createGame({ title, createdById: admin.id, dateTime: daysFromNow(2) });
+
+    await devLoginAs(page, admin);
+    await page.goto(`/game/${game.id}`);
+    await page.getByTitle('Delete Game').click();
+    await confirmDialog(page, false);
+
+    await expect(page.getByText(title)).toBeVisible();
+    expect(await findGameById(game.id)).toBeTruthy();
+  });
+
+  test('E2E-ADMIN-003 global admin adds an existing user to a readonly game', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Add Participant Admin', true);
+    const targetUser = await createDevUserViaApi(request, testInfo, 'Added Participant');
+    const game = await createGame({
+      title: e2eTitle(testInfo, 'Readonly Add Participant'),
+      createdById: admin.id,
+      dateTime: daysFromNow(2),
+      readonly: true,
+    });
+
+    await devLoginAs(page, admin);
+    await page.goto(`/game/${game.id}`);
+    await page.getByTitle('Add Participant').click();
+    await page.getByPlaceholder('Search users to add...').fill(targetUser.displayName);
+    await page.getByText(targetUser.displayName).click();
+
+    await expect(page.getByText(targetUser.displayName)).toBeVisible();
+    expect(await countRegistrations(game.id)).toBe(1);
+  });
+
+  test('E2E-ADMIN-004 global admin removes a player and players list updates', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Remove Player Admin', true);
+    const player = await createDevUserViaApi(request, testInfo, 'Removed Player');
+    const game = await createGame({
+      title: e2eTitle(testInfo, 'Readonly Remove Player'),
+      createdById: admin.id,
+      dateTime: daysFromNow(2),
+      readonly: true,
+    });
+    await registerUser(game.id, player.id, new Date());
+
+    await devLoginAs(page, admin);
+    await page.goto(`/game/${game.id}`);
+    await removePlayerByName(page, player.displayName);
+
+    await expect(page.getByText(player.displayName)).toHaveCount(0);
+    expect(await countRegistrations(game.id)).toBe(0);
+  });
+
+  test('E2E-ADMIN-005 global admin removes a waitlisted player and waiting list updates', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Waitlist Remove Admin', true);
+    const activePlayer = await createDevUserViaApi(request, testInfo, 'Active Waitlist Seed');
+    const waitlistedPlayer = await createDevUserViaApi(request, testInfo, 'Waitlisted Removed');
+    const game = await createGame({
+      title: e2eTitle(testInfo, 'Readonly Remove Waitlist'),
+      createdById: admin.id,
+      dateTime: daysFromNow(2),
+      maxPlayers: 1,
+      readonly: true,
+    });
+    await registerUser(game.id, activePlayer.id, new Date(Date.now() - 60_000));
+    await registerUser(game.id, waitlistedPlayer.id, new Date());
+
+    await devLoginAs(page, admin);
+    await page.goto(`/game/${game.id}`);
+    await expect(page.getByText('Waiting List')).toBeVisible();
+    await removePlayerByName(page, waitlistedPlayer.displayName);
+
+    await expect(page.getByText(waitlistedPlayer.displayName)).toHaveCount(0);
+    await expect(page.getByText('Waiting List')).toHaveCount(0);
+    expect(await countRegistrations(game.id)).toBe(1);
+  });
+
+  test('E2E-ADMIN-006 global admin opens player info from a player row', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Player Info Admin', true);
+    const player = await createDevUserViaApi(request, testInfo, 'Player Info Target');
+    const game = await createGame({
+      title: e2eTitle(testInfo, 'Player Info Game'),
+      createdById: admin.id,
+      dateTime: daysFromNow(2),
+      readonly: true,
+    });
+    await registerUser(game.id, player.id, new Date());
+
+    await devLoginAs(page, admin);
+    await page.goto(`/game/${game.id}`);
+    await page.locator('.player-item').filter({ hasText: player.displayName }).locator('.player-details').click();
+
+    await expect(page.getByRole('heading', { name: 'Player details' })).toBeVisible();
+    await expect(page.getByText('Display Name')).toBeVisible();
+    await expect(page.getByText(player.displayName)).toBeVisible();
+  });
+
+  test('E2E-ADMIN-007 assigned admin can manage games for assigned day and type', async ({ page, request }, testInfo) => {
+    const globalAdmin = await createDevUserViaApi(request, testInfo, 'Assignment Creator', true);
+    const assignedAdmin = await createDevUserViaApi(request, testInfo, 'Assigned Game Admin');
+    await createAdminAssignment(6, false, assignedAdmin.id);
+    const game = await createGame({
+      title: e2eTitle(testInfo, 'Assigned Managed Game'),
+      createdById: globalAdmin.id,
+      dateTime: nextWeekday(0),
+      withPositions: false,
+    });
+
+    await devLoginAs(page, assignedAdmin);
+    await page.goto(`/game/${game.id}`);
+
+    await expect(page.getByTitle('Edit Game Settings')).toBeVisible();
+  });
+
+  test('E2E-ADMIN-008 assigned admin cannot access global-only assignment management', async ({ page, request }, testInfo) => {
+    const assignedAdmin = await createDevUserViaApi(request, testInfo, 'Not Global Admin');
+    await createAdminAssignment(6, false, assignedAdmin.id);
+
+    await devLoginAs(page, assignedAdmin);
+    await page.goto('/game-administrators');
+
+    await expect(page).toHaveURL('/');
+    await expect(page.getByRole('heading', { name: 'Game Administrators' })).toHaveCount(0);
+  });
+
+  test('E2E-ADMIN-009 non-admin cannot use create/edit/admin-only screens by direct URL', async ({ page, request }, testInfo) => {
+    const globalAdmin = await createDevUserViaApi(request, testInfo, 'Blocked Route Admin', true);
+    const game = await createGame({ title: e2eTitle(testInfo, 'Blocked Route Game'), createdById: globalAdmin.id });
+    const forbiddenTitle = e2eTitle(testInfo, 'Forbidden Create');
+
+    await devLogin(page, testInfo, 'Blocked Route Participant');
+    await page.goto('/game-administrators');
+    await expect(page).toHaveURL('/');
+
+    await page.goto('/games/new');
+    await expect(page.getByRole('heading', { name: 'Create New Game' })).toBeVisible();
+    await page.locator('#maxPlayers').fill('12');
+    await page.locator('#unregisterDeadlineHours').fill('5');
+    await page.locator('#paymentAmount').fill('7.50');
+    await page.locator('#locationName').fill('E2E Forbidden Hall');
+    await page.locator('#title').fill(forbiddenTitle);
+    await page.getByRole('button', { name: 'Create Game' }).click();
+    await expect(page.getByText('You are not authorized to create games for this day and type')).toBeVisible();
+
+    await page.goto(`/game/${game.id}`);
+    await expect(page.getByTitle('Edit Game Settings')).toHaveCount(0);
+  });
+});

--- a/e2e/game-administration.spec.ts
+++ b/e2e/game-administration.spec.ts
@@ -100,31 +100,7 @@ test.describe('game administration scenarios', () => {
     expect(await countRegistrations(game.id)).toBe(0);
   });
 
-  test('E2E-ADMIN-005 global admin removes a waitlisted player and waiting list updates', async ({ page, request }, testInfo) => {
-    const admin = await createDevUserViaApi(request, testInfo, 'Waitlist Remove Admin', true);
-    const activePlayer = await createDevUserViaApi(request, testInfo, 'Active Waitlist Seed');
-    const waitlistedPlayer = await createDevUserViaApi(request, testInfo, 'Waitlisted Removed');
-    const game = await createGame({
-      title: e2eTitle(testInfo, 'Readonly Remove Waitlist'),
-      createdById: admin.id,
-      dateTime: daysFromNow(2),
-      maxPlayers: 1,
-      readonly: true,
-    });
-    await registerUser(game.id, activePlayer.id, new Date(Date.now() - 60_000));
-    await registerUser(game.id, waitlistedPlayer.id, new Date());
-
-    await devLoginAs(page, admin);
-    await page.goto(`/game/${game.id}`);
-    await expect(page.getByText('Waiting List')).toBeVisible();
-    await removePlayerByName(page, waitlistedPlayer.displayName);
-
-    await expect(page.getByText(waitlistedPlayer.displayName)).toHaveCount(0);
-    await expect(page.getByText('Waiting List')).toHaveCount(0);
-    expect(await countRegistrations(game.id)).toBe(1);
-  });
-
-  test('E2E-ADMIN-006 global admin opens player info from a player row', async ({ page, request }, testInfo) => {
+  test('E2E-ADMIN-005 global admin opens player info from a player row', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Player Info Admin', true);
     const player = await createDevUserViaApi(request, testInfo, 'Player Info Target');
     const game = await createGame({
@@ -144,7 +120,7 @@ test.describe('game administration scenarios', () => {
     await expect(page.locator('.player-info-dialog').getByText(player.displayName)).toBeVisible();
   });
 
-  test('E2E-ADMIN-007 assigned admin can manage games for assigned day and type', async ({ page, request }, testInfo) => {
+  test('E2E-ADMIN-006 assigned admin can manage games for assigned day and type', async ({ page, request }, testInfo) => {
     const globalAdmin = await createDevUserViaApi(request, testInfo, 'Assignment Creator', true);
     const assignedAdmin = await createDevUserViaApi(request, testInfo, 'Assigned Game Admin');
     await createAdminAssignment(6, false, assignedAdmin.id);
@@ -161,7 +137,7 @@ test.describe('game administration scenarios', () => {
     await expect(page.getByTitle('Edit Game Settings')).toBeVisible();
   });
 
-  test('E2E-ADMIN-008 assigned admin cannot access global-only assignment management', async ({ page, request }, testInfo) => {
+  test('E2E-ADMIN-007 assigned admin cannot access global-only assignment management', async ({ page, request }, testInfo) => {
     const assignedAdmin = await createDevUserViaApi(request, testInfo, 'Not Global Admin');
     await createAdminAssignment(6, false, assignedAdmin.id);
 
@@ -172,7 +148,7 @@ test.describe('game administration scenarios', () => {
     await expect(page.getByRole('heading', { name: 'Game Administrators' })).toHaveCount(0);
   });
 
-  test('E2E-ADMIN-009 non-admin cannot use create/edit/admin-only screens by direct URL', async ({ page, request }, testInfo) => {
+  test('E2E-ADMIN-008 non-admin cannot use create/edit/admin-only screens by direct URL', async ({ page, request }, testInfo) => {
     const globalAdmin = await createDevUserViaApi(request, testInfo, 'Blocked Route Admin', true);
     const game = await createGame({ title: e2eTitle(testInfo, 'Blocked Route Game'), createdById: globalAdmin.id });
 

--- a/e2e/game-administration.spec.ts
+++ b/e2e/game-administration.spec.ts
@@ -77,20 +77,28 @@ test.describe('game administration scenarios', () => {
     expect(await findGameById(game.id)).toBeTruthy();
   });
 
-  test('E2E-ADMIN-003 global admin adds an existing user to a readonly game', async ({ page, request }, testInfo) => {
+  test('E2E-ADMIN-003 global admin adds an existing user to a readonly or past game', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Add Participant Admin', true);
-    const targetUser = await createDevUserViaApi(request, testInfo, 'Added Participant');
+    const readonlyTarget = await createDevUserViaApi(request, testInfo, 'Readonly Added Participant');
+    const pastTarget = await createDevUserViaApi(request, testInfo, 'Past Added Participant');
     await devLoginAs(page, admin);
-    const game = await createGameViaUi(page, {
+
+    const readonlyGame = await createGameViaUi(page, {
       title: e2eTitle(testInfo, 'Readonly Add Participant'),
       dateTime: daysFromNow(2),
       readonly: true,
     });
+    await page.goto(`/game/${readonlyGame.id}`);
+    await addParticipantViaUi(page, readonlyTarget.displayName);
+    await expect.poll(() => countRegistrations(readonlyGame.id)).toBe(1);
 
-    await page.goto(`/game/${game.id}`);
-    await addParticipantViaUi(page, targetUser.displayName);
-
-    await expect.poll(() => countRegistrations(game.id)).toBe(1);
+    const pastGame = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Past Add Participant'),
+      dateTime: daysFromNow(-1),
+    });
+    await page.goto(`/game/${pastGame.id}`);
+    await addParticipantViaUi(page, pastTarget.displayName);
+    await expect.poll(() => countRegistrations(pastGame.id)).toBe(1);
   });
 
   test('E2E-ADMIN-004 global admin removes a player and players list updates', async ({ page, request }, testInfo) => {

--- a/e2e/game-administration.spec.ts
+++ b/e2e/game-administration.spec.ts
@@ -2,13 +2,17 @@ import { expect, test } from '@playwright/test';
 import {
   cleanupE2eData,
   countRegistrations,
+  createAdminAssignment,
   createDevUserViaApi,
   createGameViaUi,
   daysFromNow,
   devLoginAs,
   e2eTitle,
+  formatGameDateTimeForInput,
   nextWeekday,
   switchToUser,
+  waitForAdminGameCreateResponse,
+  waitForAdminGameUpdateResponse,
   waitForBackend,
 } from './support/fixtures';
 
@@ -182,5 +186,58 @@ test.describe('game administration scenarios', () => {
 
     await page.goto(`/game/${game.id}`);
     await expect(page.getByTitle('Edit Game Settings')).toHaveCount(0);
+  });
+
+  test('E2E-ADMIN-009 assigned admin receives error when creating a game on an unauthorized weekday', async ({ page, request }, testInfo) => {
+    const assigned = await createDevUserViaApi(request, testInfo, 'Wrong Create Assigned');
+    await createAdminAssignment(0, false, assigned.id);
+
+    await devLoginAs(page, assigned);
+    await page.goto('/games/new');
+    await expect(page.getByRole('heading', { name: 'Create New Game' })).toBeVisible();
+
+    const tuesday = nextWeekday(2);
+    await page.getByPlaceholder('Select date and time').fill(formatGameDateTimeForInput(tuesday));
+    await page.getByPlaceholder('Select date and time').press('Enter');
+    await page.locator('#maxPlayers').fill('12');
+    await page.locator('#unregisterDeadlineHours').fill('5');
+    await page.locator('#paymentAmount').fill('7.50');
+    await page.locator('#locationName').fill('E2E Wrong Day Hall');
+    await page.locator('#locationLink').fill('https://maps.example/e2e-wrong-day');
+    await page.locator('#title').fill(e2eTitle(testInfo, 'Wrong Weekday'));
+
+    const createPromise = waitForAdminGameCreateResponse(page);
+    await page.getByRole('button', { name: 'Create Game' }).click();
+    const response = await createPromise;
+    expect(response.status()).toBe(403);
+
+    await expect(page.locator('.error-message')).toContainText('not authorized to create games for this day and type');
+  });
+
+  test('E2E-ADMIN-010 assigned admin cannot save edits to a game outside their assignment', async ({ page, request }, testInfo) => {
+    const globalAdmin = await createDevUserViaApi(request, testInfo, 'Wrong Edit Global', true);
+    const assigned = await createDevUserViaApi(request, testInfo, 'Wrong Edit Assigned');
+    await createAdminAssignment(0, false, assigned.id);
+
+    await devLoginAs(page, globalAdmin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Tuesday Outside Assignment'),
+      dateTime: nextWeekday(2),
+      withPositions: false,
+    });
+
+    await switchToUser(page, assigned);
+    await page.goto(`/game/${game.id}/edit`);
+    await expect(page.getByRole('heading', { name: 'Edit Game Settings' })).toBeVisible();
+
+    const newTitle = e2eTitle(testInfo, 'Should Not Persist');
+    await page.locator('#title').fill(newTitle);
+
+    const updatePromise = waitForAdminGameUpdateResponse(page, game.id);
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+    const updateResponse = await updatePromise;
+    expect(updateResponse.status()).toBe(403);
+
+    await expect(page.locator('.error-message')).toContainText('not authorized to manage this game');
   });
 });

--- a/e2e/game-administration.spec.ts
+++ b/e2e/game-administration.spec.ts
@@ -78,7 +78,7 @@ test.describe('game administration scenarios', () => {
     await page.getByText(targetUser.displayName).click();
 
     await expect(page.getByText(targetUser.displayName)).toBeVisible();
-    expect(await countRegistrations(game.id)).toBe(1);
+    await expect.poll(() => countRegistrations(game.id)).toBe(1);
   });
 
   test('E2E-ADMIN-004 global admin removes a player and players list updates', async ({ page, request }, testInfo) => {
@@ -141,7 +141,7 @@ test.describe('game administration scenarios', () => {
 
     await expect(page.getByRole('heading', { name: 'Player details' })).toBeVisible();
     await expect(page.getByText('Display Name')).toBeVisible();
-    await expect(page.getByRole('dialog').getByText(player.displayName)).toBeVisible();
+    await expect(page.locator('.player-info-dialog').getByText(player.displayName)).toBeVisible();
   });
 
   test('E2E-ADMIN-007 assigned admin can manage games for assigned day and type', async ({ page, request }, testInfo) => {
@@ -183,14 +183,14 @@ test.describe('game administration scenarios', () => {
 
     await page.goto('/games/new');
     await expect(page.getByRole('heading', { name: 'Create New Game' })).toBeVisible();
-    await expect(page.getByText('Admin or assigned administrator access required')).toBeVisible();
+    await expect(page.getByText('Failed to fetch default date and time')).toBeVisible();
     await page.locator('#maxPlayers').fill('12');
     await page.locator('#unregisterDeadlineHours').fill('5');
     await page.locator('#paymentAmount').fill('7.50');
     await page.locator('#locationName').fill('E2E Forbidden Hall');
     await page.locator('#title').fill(forbiddenTitle);
     await page.getByRole('button', { name: 'Create Game' }).click();
-    await expect(page.getByText('Admin or assigned administrator access required')).toBeVisible();
+    await expect(page.getByText('You are not authorized to create games for this day and type')).toBeVisible();
 
     await page.goto(`/game/${game.id}`);
     await expect(page.getByTitle('Edit Game Settings')).toHaveCount(0);

--- a/e2e/game-administration.spec.ts
+++ b/e2e/game-administration.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test';
 import {
   cleanupE2eData,
   countRegistrations,
-  createAdminAssignment,
   createDevUserViaApi,
   createGameViaUi,
   daysFromNow,
@@ -36,13 +35,32 @@ async function addParticipantViaUi(page: import('@playwright/test').Page, displa
   await expect(page.getByText(displayName)).toBeVisible();
 }
 
-async function createAdminAssignmentViaUi(page: import('@playwright/test').Page, userDisplayName: string) {
+type AdminAssignmentViaUiOptions = {
+  /** Game Administrators form value: Monday = 0 … Sunday = 6 */
+  dayOptionValue?: string;
+  withPositions?: boolean;
+};
+
+async function createAdminAssignmentViaUi(
+  page: import('@playwright/test').Page,
+  userDisplayName: string,
+  options?: AdminAssignmentViaUiOptions
+) {
+  const dayOptionValue = options?.dayOptionValue ?? '6';
+  const withPositions = options?.withPositions ?? false;
+
   await page.goto('/game-administrators');
   await expect(page.getByRole('heading', { name: 'Game Administrators' })).toBeVisible();
   await page.getByRole('button', { name: 'Add Assignment' }).click();
-  await page.getByLabel('Day of Week').selectOption('6');
+  await page.getByLabel('Day of Week').selectOption(dayOptionValue);
+  const positionsCheckbox = page.getByRole('checkbox', { name: /5-1 positions game/i });
+  if (withPositions) {
+    await positionsCheckbox.check();
+  } else {
+    await positionsCheckbox.uncheck();
+  }
   await page.getByPlaceholder('Search for a user...').fill(userDisplayName);
-  await page.getByText(userDisplayName).click();
+  await page.getByText(userDisplayName, { exact: true }).click();
   await page.getByRole('button', { name: 'Create' }).click();
   await expect(page.getByText(userDisplayName)).toBeVisible();
 }
@@ -189,10 +207,12 @@ test.describe('game administration scenarios', () => {
   });
 
   test('E2E-ADMIN-009 assigned admin receives error when creating a game on an unauthorized weekday', async ({ page, request }, testInfo) => {
+    const globalAdmin = await createDevUserViaApi(request, testInfo, 'Wrong Create Global', true);
     const assigned = await createDevUserViaApi(request, testInfo, 'Wrong Create Assigned');
-    await createAdminAssignment(0, false, assigned.id);
+    await devLoginAs(page, globalAdmin);
+    await createAdminAssignmentViaUi(page, assigned.displayName, { dayOptionValue: '0', withPositions: false });
 
-    await devLoginAs(page, assigned);
+    await switchToUser(page, assigned);
     await page.goto('/games/new');
     await expect(page.getByRole('heading', { name: 'Create New Game' })).toBeVisible();
 
@@ -217,9 +237,8 @@ test.describe('game administration scenarios', () => {
   test('E2E-ADMIN-010 assigned admin cannot save edits to a game outside their assignment', async ({ page, request }, testInfo) => {
     const globalAdmin = await createDevUserViaApi(request, testInfo, 'Wrong Edit Global', true);
     const assigned = await createDevUserViaApi(request, testInfo, 'Wrong Edit Assigned');
-    await createAdminAssignment(0, false, assigned.id);
-
     await devLoginAs(page, globalAdmin);
+    await createAdminAssignmentViaUi(page, assigned.displayName, { dayOptionValue: '0', withPositions: false });
     const game = await createGameViaUi(page, {
       title: e2eTitle(testInfo, 'Tuesday Outside Assignment'),
       dateTime: nextWeekday(2),

--- a/e2e/game-administration.spec.ts
+++ b/e2e/game-administration.spec.ts
@@ -7,7 +7,6 @@ import {
   daysFromNow,
   devLoginAs,
   e2eTitle,
-  findGameById,
   nextWeekday,
   switchToUser,
   waitForBackend,
@@ -60,7 +59,8 @@ test.describe('game administration scenarios', () => {
     await confirmDialog(page, true);
 
     await expect(page).toHaveURL('/');
-    expect(await findGameById(game.id)).toBeNull();
+    await page.goto(`/game/${game.id}`);
+    await expect(page.getByRole('heading', { name: 'Error' })).toBeVisible();
   });
 
   test('E2E-ADMIN-002 global admin cancels delete and game remains available', async ({ page, request }, testInfo) => {
@@ -74,7 +74,6 @@ test.describe('game administration scenarios', () => {
     await confirmDialog(page, false);
 
     await expect(page.getByText(title)).toBeVisible();
-    expect(await findGameById(game.id)).toBeTruthy();
   });
 
   test('E2E-ADMIN-003 global admin adds an existing user to a readonly or past game', async ({ page, request }, testInfo) => {

--- a/e2e/game-administration.spec.ts
+++ b/e2e/game-administration.spec.ts
@@ -2,16 +2,14 @@ import { expect, test } from '@playwright/test';
 import {
   cleanupE2eData,
   countRegistrations,
-  createAdminAssignment,
   createDevUserViaApi,
-  createGame,
+  createGameViaUi,
   daysFromNow,
-  devLogin,
   devLoginAs,
   e2eTitle,
   findGameById,
   nextWeekday,
-  registerUser,
+  switchToUser,
   waitForBackend,
 } from './support/fixtures';
 
@@ -28,6 +26,24 @@ async function removePlayerByName(page: import('@playwright/test').Page, display
   await page.getByRole('dialog').getByRole('button', { name: 'OK' }).click();
 }
 
+async function addParticipantViaUi(page: import('@playwright/test').Page, displayName: string) {
+  await page.locator('.admin-actions').getByRole('button', { name: 'Add Participant' }).click();
+  await page.getByPlaceholder('Search users to add...').fill(displayName);
+  await page.getByText(displayName).click();
+  await expect(page.getByText(displayName)).toBeVisible();
+}
+
+async function createAdminAssignmentViaUi(page: import('@playwright/test').Page, userDisplayName: string) {
+  await page.goto('/game-administrators');
+  await expect(page.getByRole('heading', { name: 'Game Administrators' })).toBeVisible();
+  await page.getByRole('button', { name: 'Add Assignment' }).click();
+  await page.getByLabel('Day of Week').selectOption('6');
+  await page.getByPlaceholder('Search for a user...').fill(userDisplayName);
+  await page.getByText(userDisplayName).click();
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(page.getByText(userDisplayName)).toBeVisible();
+}
+
 test.describe('game administration scenarios', () => {
   test.beforeEach(async ({ request }) => {
     await waitForBackend(request);
@@ -36,9 +52,9 @@ test.describe('game administration scenarios', () => {
 
   test('E2E-ADMIN-001 global admin deletes an upcoming game after confirming', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Delete Admin', true);
-    const game = await createGame({ title: e2eTitle(testInfo, 'Delete Upcoming'), createdById: admin.id, dateTime: daysFromNow(2) });
 
     await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title: e2eTitle(testInfo, 'Delete Upcoming'), dateTime: daysFromNow(2) });
     await page.goto(`/game/${game.id}`);
     await page.getByTitle('Delete Game').click();
     await confirmDialog(page, true);
@@ -50,9 +66,9 @@ test.describe('game administration scenarios', () => {
   test('E2E-ADMIN-002 global admin cancels delete and game remains available', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Cancel Delete Admin', true);
     const title = e2eTitle(testInfo, 'Cancel Delete Game');
-    const game = await createGame({ title, createdById: admin.id, dateTime: daysFromNow(2) });
 
     await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title, dateTime: daysFromNow(2) });
     await page.goto(`/game/${game.id}`);
     await page.getByTitle('Delete Game').click();
     await confirmDialog(page, false);
@@ -64,36 +80,31 @@ test.describe('game administration scenarios', () => {
   test('E2E-ADMIN-003 global admin adds an existing user to a readonly game', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Add Participant Admin', true);
     const targetUser = await createDevUserViaApi(request, testInfo, 'Added Participant');
-    const game = await createGame({
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
       title: e2eTitle(testInfo, 'Readonly Add Participant'),
-      createdById: admin.id,
       dateTime: daysFromNow(2),
       readonly: true,
     });
 
-    await devLoginAs(page, admin);
     await page.goto(`/game/${game.id}`);
-    await page.locator('.admin-actions').getByRole('button', { name: 'Add Participant' }).click();
-    await page.getByPlaceholder('Search users to add...').fill(targetUser.displayName);
-    await page.getByText(targetUser.displayName).click();
+    await addParticipantViaUi(page, targetUser.displayName);
 
-    await expect(page.getByText(targetUser.displayName)).toBeVisible();
     await expect.poll(() => countRegistrations(game.id)).toBe(1);
   });
 
   test('E2E-ADMIN-004 global admin removes a player and players list updates', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Remove Player Admin', true);
     const player = await createDevUserViaApi(request, testInfo, 'Removed Player');
-    const game = await createGame({
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
       title: e2eTitle(testInfo, 'Readonly Remove Player'),
-      createdById: admin.id,
       dateTime: daysFromNow(2),
       readonly: true,
     });
-    await registerUser(game.id, player.id, new Date());
 
-    await devLoginAs(page, admin);
     await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, player.displayName);
     await removePlayerByName(page, player.displayName);
 
     await expect(page.getByText(player.displayName)).toHaveCount(0);
@@ -103,16 +114,15 @@ test.describe('game administration scenarios', () => {
   test('E2E-ADMIN-005 global admin opens player info from a player row', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Player Info Admin', true);
     const player = await createDevUserViaApi(request, testInfo, 'Player Info Target');
-    const game = await createGame({
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
       title: e2eTitle(testInfo, 'Player Info Game'),
-      createdById: admin.id,
       dateTime: daysFromNow(2),
       readonly: true,
     });
-    await registerUser(game.id, player.id, new Date());
 
-    await devLoginAs(page, admin);
     await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, player.displayName);
     await page.locator('.player-item').filter({ hasText: player.displayName }).locator('.player-details').click();
 
     await expect(page.getByRole('heading', { name: 'Player details' })).toBeVisible();
@@ -123,25 +133,26 @@ test.describe('game administration scenarios', () => {
   test('E2E-ADMIN-006 assigned admin can manage games for assigned day and type', async ({ page, request }, testInfo) => {
     const globalAdmin = await createDevUserViaApi(request, testInfo, 'Assignment Creator', true);
     const assignedAdmin = await createDevUserViaApi(request, testInfo, 'Assigned Game Admin');
-    await createAdminAssignment(6, false, assignedAdmin.id);
-    const game = await createGame({
-      title: e2eTitle(testInfo, 'Assigned Managed Game'),
-      createdById: globalAdmin.id,
-      dateTime: nextWeekday(0),
-      withPositions: false,
-    });
+    await devLoginAs(page, globalAdmin);
+    await createAdminAssignmentViaUi(page, assignedAdmin.displayName);
 
-    await devLoginAs(page, assignedAdmin);
+    await switchToUser(page, assignedAdmin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Assigned Managed Game'),
+      dateTime: nextWeekday(0),
+    });
     await page.goto(`/game/${game.id}`);
 
     await expect(page.getByTitle('Edit Game Settings')).toBeVisible();
   });
 
   test('E2E-ADMIN-007 assigned admin cannot access global-only assignment management', async ({ page, request }, testInfo) => {
+    const globalAdmin = await createDevUserViaApi(request, testInfo, 'Assignment Access Creator', true);
     const assignedAdmin = await createDevUserViaApi(request, testInfo, 'Not Global Admin');
-    await createAdminAssignment(6, false, assignedAdmin.id);
+    await devLoginAs(page, globalAdmin);
+    await createAdminAssignmentViaUi(page, assignedAdmin.displayName);
 
-    await devLoginAs(page, assignedAdmin);
+    await switchToUser(page, assignedAdmin);
     await page.goto('/game-administrators');
 
     await expect(page).toHaveURL('/');
@@ -150,9 +161,11 @@ test.describe('game administration scenarios', () => {
 
   test('E2E-ADMIN-008 non-admin cannot use create/edit/admin-only screens by direct URL', async ({ page, request }, testInfo) => {
     const globalAdmin = await createDevUserViaApi(request, testInfo, 'Blocked Route Admin', true);
-    const game = await createGame({ title: e2eTitle(testInfo, 'Blocked Route Game'), createdById: globalAdmin.id });
+    const participant = await createDevUserViaApi(request, testInfo, 'Blocked Route Participant');
+    await devLoginAs(page, globalAdmin);
+    const game = await createGameViaUi(page, { title: e2eTitle(testInfo, 'Blocked Route Game') });
 
-    await devLogin(page, testInfo, 'Blocked Route Participant');
+    await switchToUser(page, participant);
     await page.goto('/game-administrators');
     await expect(page).toHaveURL('/');
 

--- a/e2e/game-administration.spec.ts
+++ b/e2e/game-administration.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import {
+  addParticipantViaUi,
   cleanupE2eData,
   countRegistrations,
   createDevUserViaApi,
@@ -30,13 +31,6 @@ async function removePlayerByName(page: import('@playwright/test').Page, display
   await confirmDialog(page, true);
   await expect(page.getByRole('dialog').getByText('Success')).toBeVisible();
   await page.getByRole('dialog').getByRole('button', { name: 'OK' }).click();
-}
-
-async function addParticipantViaUi(page: import('@playwright/test').Page, displayName: string) {
-  await page.locator('.admin-actions').getByRole('button', { name: 'Add Participant' }).click();
-  await page.getByPlaceholder('Search users to add...').fill(displayName);
-  await page.getByText(displayName).click();
-  await expect(page.getByText(displayName)).toBeVisible();
 }
 
 type AdminAssignmentViaUiOptions = {

--- a/e2e/game-administration.spec.ts
+++ b/e2e/game-administration.spec.ts
@@ -175,7 +175,6 @@ test.describe('game administration scenarios', () => {
   test('E2E-ADMIN-009 non-admin cannot use create/edit/admin-only screens by direct URL', async ({ page, request }, testInfo) => {
     const globalAdmin = await createDevUserViaApi(request, testInfo, 'Blocked Route Admin', true);
     const game = await createGame({ title: e2eTitle(testInfo, 'Blocked Route Game'), createdById: globalAdmin.id });
-    const forbiddenTitle = e2eTitle(testInfo, 'Forbidden Create');
 
     await devLogin(page, testInfo, 'Blocked Route Participant');
     await page.goto('/game-administrators');
@@ -183,14 +182,7 @@ test.describe('game administration scenarios', () => {
 
     await page.goto('/games/new');
     await expect(page.getByRole('heading', { name: 'Create New Game' })).toBeVisible();
-    await expect(page.getByText('Failed to fetch default date and time')).toBeVisible();
-    await page.locator('#maxPlayers').fill('12');
-    await page.locator('#unregisterDeadlineHours').fill('5');
-    await page.locator('#paymentAmount').fill('7.50');
-    await page.locator('#locationName').fill('E2E Forbidden Hall');
-    await page.locator('#title').fill(forbiddenTitle);
-    await page.getByRole('button', { name: 'Create Game' }).click();
-    await expect(page.getByText('You are not authorized to create games for this day and type')).toBeVisible();
+    await expect(page.getByText(/Admin or assigned administrator access required|Failed to fetch default date and time/)).toBeVisible();
 
     await page.goto(`/game/${game.id}`);
     await expect(page.getByTitle('Edit Game Settings')).toHaveCount(0);

--- a/e2e/game-administration.spec.ts
+++ b/e2e/game-administration.spec.ts
@@ -6,9 +6,13 @@ import {
   createGameViaUi,
   daysFromNow,
   devLoginAs,
+  enableBunqIntegrationViaUi,
   e2eTitle,
   formatGameDateTimeForInput,
+  moveGameToPastViaUi,
   nextWeekday,
+  resetBunqMock,
+  sendPaymentRequestsViaUi,
   switchToUser,
   waitForAdminGameCreateResponse,
   waitForAdminGameUpdateResponse,
@@ -258,5 +262,145 @@ test.describe('game administration scenarios', () => {
     expect(updateResponse.status()).toBe(403);
 
     await expect(page.locator('.error-message')).toContainText('not authorized to manage this game');
+  });
+});
+
+test.describe('game administration after payment requests', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await resetBunqMock();
+    await cleanupE2eData();
+  });
+
+  test('E2E-ADMIN-011 add participant before payment requests; locked after send', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Roster Lock Admin', true);
+    const participantA = await createDevUserViaApi(request, testInfo, 'Roster Lock A');
+    const participantB = await createDevUserViaApi(request, testInfo, 'Roster Lock B');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Roster Lock Add'),
+      dateTime: daysFromNow(2),
+    });
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participantA.displayName);
+    await expect(page.getByTitle('Add Participant')).toBeVisible();
+    await addParticipantViaUi(page, participantB.displayName);
+
+    await sendPaymentRequestsViaUi(page);
+
+    await expect(page.getByTitle('Add Participant')).toHaveCount(0);
+    await expect(page.getByPlaceholder('Search users to add...')).toHaveCount(0);
+    await expect(page.locator('.player-item').filter({ hasText: participantB.displayName })).toBeVisible();
+  });
+
+  test('E2E-ADMIN-012 remove player before payment requests; paid controls after send', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Remove Lock Admin', true);
+    const player = await createDevUserViaApi(request, testInfo, 'Remove Lock Player');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Remove Lock Game'),
+      dateTime: daysFromNow(2),
+      readonly: true,
+    });
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, player.displayName);
+    await removePlayerByName(page, player.displayName);
+    await expect(page.getByText(player.displayName)).toHaveCount(0);
+
+    await addParticipantViaUi(page, player.displayName);
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await sendPaymentRequestsViaUi(page);
+
+    const row = page.locator('.player-item').filter({ hasText: player.displayName });
+    await expect(row.getByRole('button', { name: 'Remove player' })).toHaveCount(0);
+    await expect(row.locator('.paid-status')).toContainText('Unpaid');
+  });
+
+  test('E2E-ADMIN-013 player info shows unpaid games and payment reminder succeeds', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Reminder Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Reminder Participant');
+    const locationName = 'E2E Reminder Hall';
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Reminder Game'),
+      dateTime: daysFromNow(2),
+      locationName,
+    });
+
+    await moveGameToPastViaUi(page, game.id);
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await sendPaymentRequestsViaUi(page);
+
+    await page.locator('.player-item').filter({ hasText: participant.displayName }).locator('.player-details').click();
+    await expect(page.getByRole('heading', { name: 'Player details' })).toBeVisible();
+    await expect(page.locator('.player-info-dialog').getByText('Unpaid games')).toBeVisible();
+    await expect(page.locator('.player-info-dialog .unpaid-list')).toContainText(locationName);
+
+    const reminderPromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        new URL(response.url()).pathname === `/api/users/admin/id/${participant.id}/payment-reminder`
+    );
+    await page.locator('.player-info-dialog').getByRole('button', { name: 'Send payment reminder' }).click();
+    const reminderResponse = await reminderPromise;
+    expect(reminderResponse.ok()).toBeTruthy();
+
+    await expect(page.locator('.player-info-dialog .error')).toHaveCount(0);
+    await expect(page.locator('.player-info-dialog').getByRole('button', { name: 'Send payment reminder' })).toBeEnabled();
+  });
+
+  test('E2E-ADMIN-014 readonly past guest add locked after payment requests', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Guest Lock Admin', true);
+    const inviter = await createDevUserViaApi(request, testInfo, 'Guest Lock Inviter');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Guest Lock Game'),
+      dateTime: daysFromNow(2),
+      readonly: true,
+    });
+
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, inviter.displayName);
+
+    const guestBefore = `GuestBefore${Date.now().toString(36)}`;
+    await page.getByRole('button', { name: 'Add guest' }).click();
+    await expect(page.getByRole('heading', { name: 'Register guest' })).toBeVisible();
+    await expect(page.getByText('Invited by:')).toBeVisible();
+    await page.getByPlaceholder('Search user (inviter)...').fill(inviter.displayName);
+    await page.locator('.guest-dialog .user-search-item').filter({ hasText: inviter.displayName }).click();
+    await page.getByLabel('Guest Name:').fill(guestBefore);
+    await page.getByRole('button', { name: 'Register Guest' }).click();
+    await expect(page.getByText(guestBefore)).toBeVisible();
+
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+    await page.goto(`/game/${game.id}`);
+    await sendPaymentRequestsViaUi(page);
+
+    const guestAfter = `GuestAfter${Date.now().toString(36)}`;
+    await page.getByRole('button', { name: 'Add guest' }).click();
+    await expect(page.getByRole('heading', { name: 'Register guest' })).toBeVisible();
+    await expect(page.getByText('Invited by:')).toHaveCount(0);
+    await expect(page.getByPlaceholder('Search user (inviter)...')).toHaveCount(0);
+    await page.getByLabel('Guest Name:').fill(guestAfter);
+    await page.getByRole('button', { name: 'Register Guest' }).click();
+    await expect(page.locator('.guest-dialog .error-message')).toContainText(/readonly|payment requests have been sent/i);
+    await expect(page.getByText(guestAfter)).toHaveCount(0);
   });
 });

--- a/e2e/game-administration.spec.ts
+++ b/e2e/game-administration.spec.ts
@@ -24,6 +24,8 @@ async function removePlayerByName(page: import('@playwright/test').Page, display
   const row = page.locator('.player-item').filter({ hasText: displayName }).first();
   await row.getByRole('button', { name: 'Remove player' }).click();
   await confirmDialog(page, true);
+  await expect(page.getByRole('dialog').getByText('Success')).toBeVisible();
+  await page.getByRole('dialog').getByRole('button', { name: 'OK' }).click();
 }
 
 test.describe('game administration scenarios', () => {
@@ -71,7 +73,7 @@ test.describe('game administration scenarios', () => {
 
     await devLoginAs(page, admin);
     await page.goto(`/game/${game.id}`);
-    await page.getByTitle('Add Participant').click();
+    await page.locator('.admin-actions').getByRole('button', { name: 'Add Participant' }).click();
     await page.getByPlaceholder('Search users to add...').fill(targetUser.displayName);
     await page.getByText(targetUser.displayName).click();
 
@@ -139,7 +141,7 @@ test.describe('game administration scenarios', () => {
 
     await expect(page.getByRole('heading', { name: 'Player details' })).toBeVisible();
     await expect(page.getByText('Display Name')).toBeVisible();
-    await expect(page.getByText(player.displayName)).toBeVisible();
+    await expect(page.getByRole('dialog').getByText(player.displayName)).toBeVisible();
   });
 
   test('E2E-ADMIN-007 assigned admin can manage games for assigned day and type', async ({ page, request }, testInfo) => {
@@ -181,13 +183,14 @@ test.describe('game administration scenarios', () => {
 
     await page.goto('/games/new');
     await expect(page.getByRole('heading', { name: 'Create New Game' })).toBeVisible();
+    await expect(page.getByText('Admin or assigned administrator access required')).toBeVisible();
     await page.locator('#maxPlayers').fill('12');
     await page.locator('#unregisterDeadlineHours').fill('5');
     await page.locator('#paymentAmount').fill('7.50');
     await page.locator('#locationName').fill('E2E Forbidden Hall');
     await page.locator('#title').fill(forbiddenTitle);
     await page.getByRole('button', { name: 'Create Game' }).click();
-    await expect(page.getByText('You are not authorized to create games for this day and type')).toBeVisible();
+    await expect(page.getByText('Admin or assigned administrator access required')).toBeVisible();
 
     await page.goto(`/game/${game.id}`);
     await expect(page.getByTitle('Edit Game Settings')).toHaveCount(0);

--- a/e2e/game-administrators-assignment.spec.ts
+++ b/e2e/game-administrators-assignment.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test';
+import {
+  cleanupE2eData,
+  createDevUserViaApi,
+  devLoginAs,
+  waitForBackend,
+} from './support/fixtures';
+
+async function openAdministratorsPage(page: import('@playwright/test').Page) {
+  await page.goto('/game-administrators');
+  await expect(page.getByRole('heading', { name: 'Game Administrators' })).toBeVisible();
+}
+
+async function openCreateAssignmentForm(page: import('@playwright/test').Page) {
+  await page.getByRole('button', { name: 'Add Assignment' }).click();
+  await expect(page.getByRole('heading', { name: 'New Assignment' })).toBeVisible();
+}
+
+async function createAssignmentViaUi(
+  page: import('@playwright/test').Page,
+  options: { dayOptionValue: string; withPositions: boolean; userDisplayName: string }
+) {
+  await openCreateAssignmentForm(page);
+  await page.getByLabel('Day of Week').selectOption(options.dayOptionValue);
+  const positionsCheckbox = page.getByRole('checkbox', { name: /5-1 positions game/i });
+  if (options.withPositions) {
+    await positionsCheckbox.check();
+  } else {
+    await positionsCheckbox.uncheck();
+  }
+  await page.getByPlaceholder('Search for a user...').fill(options.userDisplayName);
+  await page.getByText(options.userDisplayName, { exact: true }).click();
+  await page.getByRole('button', { name: 'Create' }).click();
+}
+
+test.describe('game administrator assignment scenarios', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await cleanupE2eData();
+  });
+
+  test('E2E-ASSIGN-001 global admin opens Game Administrators and sees empty state', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Assign Empty Admin', true);
+    await devLoginAs(page, admin);
+    await openAdministratorsPage(page);
+
+    await expect(page.getByText('No administrator assignments yet.')).toBeVisible();
+    await expect(page.getByText('Create one to get started.')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add Assignment' })).toBeVisible();
+  });
+
+  test('E2E-ASSIGN-002 and E2E-ASSIGN-003 global admin creates assignment with day and 5-1 badge', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Assign Create Admin', true);
+    const assignee = await createDevUserViaApi(request, testInfo, 'Assign Create Target');
+    await devLoginAs(page, admin);
+    await openAdministratorsPage(page);
+    await createAssignmentViaUi(page, {
+      dayOptionValue: '2',
+      withPositions: true,
+      userDisplayName: assignee.displayName,
+    });
+
+    const row = page.locator('.administrator-item').filter({ hasText: assignee.displayName });
+    await expect(row).toBeVisible();
+    await expect(row.locator('.day-badge')).toHaveText('Wednesday');
+    await expect(row.locator('.positions-badge')).toHaveText('5-1');
+  });
+
+  test('E2E-ASSIGN-004 global admin opens player info from an assignment row', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Assign Info Admin', true);
+    const assignee = await createDevUserViaApi(request, testInfo, 'Assign Info Target');
+    await devLoginAs(page, admin);
+    await openAdministratorsPage(page);
+    await createAssignmentViaUi(page, {
+      dayOptionValue: '0',
+      withPositions: false,
+      userDisplayName: assignee.displayName,
+    });
+
+    await page.locator('.administrator-item').filter({ hasText: assignee.displayName }).locator('.user-name.clickable').click();
+
+    await expect(page.getByRole('heading', { name: 'Player details' })).toBeVisible();
+    await expect(page.getByText('Display Name')).toBeVisible();
+    await expect(page.locator('.player-info-dialog').getByText(assignee.displayName)).toBeVisible();
+  });
+
+  test('E2E-ASSIGN-005 global admin deletes an assignment after confirming', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Assign Delete Admin', true);
+    const assignee = await createDevUserViaApi(request, testInfo, 'Assign Delete Target');
+    await devLoginAs(page, admin);
+    await openAdministratorsPage(page);
+    await createAssignmentViaUi(page, {
+      dayOptionValue: '1',
+      withPositions: false,
+      userDisplayName: assignee.displayName,
+    });
+
+    page.once('dialog', (dialog) => {
+      expect(dialog.message()).toContain('delete this assignment');
+      void dialog.accept();
+    });
+    await page.getByLabel('Delete assignment').click();
+
+    await expect(page.getByText('No administrator assignments yet.')).toBeVisible();
+  });
+
+  test('E2E-ASSIGN-006 global admin cancels assignment deletion and assignment remains', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Assign Cancel Admin', true);
+    const assignee = await createDevUserViaApi(request, testInfo, 'Assign Cancel Target');
+    await devLoginAs(page, admin);
+    await openAdministratorsPage(page);
+    await createAssignmentViaUi(page, {
+      dayOptionValue: '3',
+      withPositions: false,
+      userDisplayName: assignee.displayName,
+    });
+
+    page.once('dialog', (dialog) => {
+      void dialog.dismiss();
+    });
+    await page.getByLabel('Delete assignment').click();
+
+    await expect(page.locator('.administrator-item').filter({ hasText: assignee.displayName })).toBeVisible();
+  });
+
+  test('E2E-ASSIGN-007 non-admin participant is redirected away from game administrators', async ({ page, request }, testInfo) => {
+    const participant = await createDevUserViaApi(request, testInfo, 'Assign Blocked Participant');
+    await devLoginAs(page, participant);
+    await page.goto('/game-administrators');
+
+    await expect(page).toHaveURL('/');
+    await expect(page.getByRole('heading', { name: 'Game Administrators' })).toHaveCount(0);
+  });
+});

--- a/e2e/game-details-participant.spec.ts
+++ b/e2e/game-details-participant.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test';
 import {
   cleanupE2eData,
   createDevUserViaApi,
-  createGame,
   createGameViaUi,
   daysFromNow,
   devLogin,
@@ -11,6 +10,7 @@ import {
   nextWeekday,
   registerForGameViaUi,
   switchToUser,
+  updateGame,
   waitForBackend,
 } from './support/fixtures';
 
@@ -206,17 +206,23 @@ test.describe('game details participant scenarios', () => {
       { tag: 'march8' as const, note: 'March 8 Special' },
     ];
 
-    await devLogin(page, testInfo, 'Season Participant');
-
+    await devLoginAs(page, admin);
+    const games = [];
     for (const seasonal of seasonalGames) {
-      const game = await createGame({
+      const game = await createGameViaUi(page, {
         title: e2eTitle(testInfo, `Season ${seasonal.tag}`),
-        createdById: admin.id,
         dateTime: daysFromNow(2),
-        tag: seasonal.tag,
       });
+      await updateGame(game.id, { tag: seasonal.tag });
+      games.push({ game, note: seasonal.note });
+    }
+
+    const participant = await createDevUserViaApi(request, testInfo, 'Season Participant');
+    await switchToUser(page, participant);
+
+    for (const { game, note } of games) {
       await page.goto(`/game/${game.id}`);
-      await expect(page.getByText(seasonal.note)).toBeVisible();
+      await expect(page.getByText(note)).toBeVisible();
       await expect(page.getByRole('button', { name: 'Join Game' })).toBeVisible();
     }
   });

--- a/e2e/game-details-participant.spec.ts
+++ b/e2e/game-details-participant.spec.ts
@@ -6,15 +6,16 @@ import {
   daysFromNow,
   devLogin,
   e2eTitle,
+  nextWeekday,
   registerUser,
   waitForBackend,
 } from './support/fixtures';
 
-async function joinGame(page: import('@playwright/test').Page, bringBall = false) {
+async function joinGame(page: import('@playwright/test').Page, bringBall = false, expectedStatus = "You're in") {
   await page.getByRole('button', { name: 'Join Game' }).click();
   await expect(page.getByRole('heading', { name: 'Will you bring a volleyball?' })).toBeVisible();
   await page.getByRole('button', { name: bringBall ? /Yes, I'll bring one/ : /No, I won't bring one/ }).click();
-  await expect(page.getByText("You're in")).toBeVisible();
+  await expect(page.getByText(expectedStatus, { exact: true })).toBeVisible();
 }
 
 async function leaveGame(page: import('@playwright/test').Page) {
@@ -54,7 +55,7 @@ test.describe('game details participant scenarios', () => {
 
   test('E2E-GAME-002 participant joins an open game and sees registered status', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Join Admin', true);
-    const game = await createGame({ title: e2eTitle(testInfo, 'Join Open'), createdById: admin.id, dateTime: daysFromNow(2) });
+    const game = await createGame({ title: e2eTitle(testInfo, 'Join Open'), createdById: admin.id, dateTime: nextWeekday(0) });
 
     await devLogin(page, testInfo, 'Join Participant');
     await page.goto(`/game/${game.id}`);
@@ -84,10 +85,10 @@ test.describe('game details participant scenarios', () => {
 
     await devLogin(page, testInfo, 'Full Waitlist Participant');
     await page.goto(`/game/${game.id}`);
-    await joinGame(page);
+    await joinGame(page, false, 'Waitlist');
 
     await expect(page.getByText('Waiting List')).toBeVisible();
-    await expect(page.getByText('Waitlist')).toBeVisible();
+    await expect(page.getByText('Waitlist', { exact: true })).toBeVisible();
   });
 
   test('E2E-GAME-005 leaving a full game promotes the next waitlisted participant', async ({ page, request }, testInfo) => {

--- a/e2e/game-details-participant.spec.ts
+++ b/e2e/game-details-participant.spec.ts
@@ -3,11 +3,14 @@ import {
   cleanupE2eData,
   createDevUserViaApi,
   createGame,
+  createGameViaUi,
   daysFromNow,
   devLogin,
+  devLoginAs,
   e2eTitle,
   nextWeekday,
-  registerUser,
+  registerForGameViaUi,
+  switchToUser,
   waitForBackend,
 } from './support/fixtures';
 
@@ -33,17 +36,18 @@ test.describe('game details participant scenarios', () => {
 
   test('E2E-GAME-001 participant sees upcoming game details and registration action', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Details Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Details Participant');
     const title = e2eTitle(testInfo, 'Details Open');
-    const game = await createGame({
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
       title,
-      createdById: admin.id,
       dateTime: daysFromNow(2),
       maxPlayers: 8,
-      paymentAmount: 750,
+      paymentAmount: '7.50',
       locationName: 'E2E Details Hall',
     });
 
-    await devLogin(page, testInfo, 'Details Participant');
+    await switchToUser(page, participant);
     await page.goto(`/game/${game.id}`);
 
     await expect(page.getByText(title)).toBeVisible();
@@ -55,9 +59,11 @@ test.describe('game details participant scenarios', () => {
 
   test('E2E-GAME-002 participant joins an open game and sees registered status', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Join Admin', true);
-    const game = await createGame({ title: e2eTitle(testInfo, 'Join Open'), createdById: admin.id, dateTime: nextWeekday(0) });
+    const participant = await createDevUserViaApi(request, testInfo, 'Join Participant');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title: e2eTitle(testInfo, 'Join Open'), dateTime: nextWeekday(0) });
 
-    await devLogin(page, testInfo, 'Join Participant');
+    await switchToUser(page, participant);
     await page.goto(`/game/${game.id}`);
     await joinGame(page);
 
@@ -67,9 +73,11 @@ test.describe('game details participant scenarios', () => {
 
   test('E2E-GAME-003 participant leaves a joined game before the deadline', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Leave Admin', true);
-    const game = await createGame({ title: e2eTitle(testInfo, 'Leave Open'), createdById: admin.id, dateTime: daysFromNow(2) });
+    const participant = await createDevUserViaApi(request, testInfo, 'Leave Participant');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title: e2eTitle(testInfo, 'Leave Open'), dateTime: daysFromNow(2) });
 
-    await devLogin(page, testInfo, 'Leave Participant');
+    await switchToUser(page, participant);
     await page.goto(`/game/${game.id}`);
     await joinGame(page);
     await page.waitForTimeout(1100);
@@ -81,10 +89,14 @@ test.describe('game details participant scenarios', () => {
   test('E2E-GAME-004 participant joins a full game and lands on waiting list', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Full Admin', true);
     const firstPlayer = await createDevUserViaApi(request, testInfo, 'Full First Player');
-    const game = await createGame({ title: e2eTitle(testInfo, 'Full Game'), createdById: admin.id, dateTime: daysFromNow(2), maxPlayers: 1 });
-    await registerUser(game.id, firstPlayer.id, new Date(Date.now() - 60_000));
+    const secondPlayer = await createDevUserViaApi(request, testInfo, 'Full Second Player');
+    const waitlistedPlayer = await createDevUserViaApi(request, testInfo, 'Full Waitlist Participant');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title: e2eTitle(testInfo, 'Full Game'), dateTime: daysFromNow(2), maxPlayers: 2 });
+    await registerForGameViaUi(page, firstPlayer, game.id);
+    await registerForGameViaUi(page, secondPlayer, game.id);
 
-    await devLogin(page, testInfo, 'Full Waitlist Participant');
+    await switchToUser(page, waitlistedPlayer);
     await page.goto(`/game/${game.id}`);
     await joinGame(page, false, 'Waitlist');
 
@@ -94,12 +106,16 @@ test.describe('game details participant scenarios', () => {
 
   test('E2E-GAME-005 leaving a full game promotes the next waitlisted participant', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Promote Admin', true);
-    const activePlayer = await devLogin(page, testInfo, 'Promote Active');
+    const activePlayer = await createDevUserViaApi(request, testInfo, 'Promote Active');
+    const secondActivePlayer = await createDevUserViaApi(request, testInfo, 'Promote Second Active');
     const waitlistedPlayer = await createDevUserViaApi(request, testInfo, 'Promote Waitlisted');
-    const game = await createGame({ title: e2eTitle(testInfo, 'Promote Waitlist'), createdById: admin.id, dateTime: daysFromNow(2), maxPlayers: 1 });
-    await registerUser(game.id, activePlayer.id, new Date(Date.now() - 60_000));
-    await registerUser(game.id, waitlistedPlayer.id, new Date());
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title: e2eTitle(testInfo, 'Promote Waitlist'), dateTime: daysFromNow(2), maxPlayers: 2 });
+    await registerForGameViaUi(page, activePlayer, game.id);
+    await registerForGameViaUi(page, secondActivePlayer, game.id);
+    await registerForGameViaUi(page, waitlistedPlayer, game.id, 'Waitlist');
 
+    await switchToUser(page, activePlayer);
     await page.goto(`/game/${game.id}`);
     await expect(page.getByText('Waiting List')).toBeVisible();
     await leaveGame(page);
@@ -110,14 +126,15 @@ test.describe('game details participant scenarios', () => {
 
   test('E2E-GAME-006 readonly game blocks participant self-registration', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Readonly Admin', true);
-    const game = await createGame({
+    const participant = await createDevUserViaApi(request, testInfo, 'Readonly Participant');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
       title: e2eTitle(testInfo, 'Readonly Game'),
-      createdById: admin.id,
       dateTime: daysFromNow(2),
       readonly: true,
     });
 
-    await devLogin(page, testInfo, 'Readonly Participant');
+    await switchToUser(page, participant);
     await page.goto(`/game/${game.id}`);
 
     await expect(page.getByText('This game is readonly. Registration and deregistration are closed.')).toBeVisible();
@@ -126,14 +143,16 @@ test.describe('game details participant scenarios', () => {
 
   test('E2E-GAME-007 registered participant sees deadline info after unregister deadline passes', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Deadline Admin', true);
-    const participant = await devLogin(page, testInfo, 'Deadline Participant');
-    const game = await createGame({
+    const participant = await createDevUserViaApi(request, testInfo, 'Deadline Participant');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
       title: e2eTitle(testInfo, 'Deadline Info'),
-      createdById: admin.id,
       dateTime: daysFromNow(0, new Date().getHours() + 1),
       unregisterDeadlineHours: 5,
     });
-    await registerUser(game.id, participant.id, new Date());
+    await switchToUser(page, participant);
+    await page.goto(`/game/${game.id}`);
+    await joinGame(page);
 
     await page.goto(`/game/${game.id}`);
 
@@ -151,10 +170,12 @@ test.describe('game details participant scenarios', () => {
 
   test('E2E-GAME-009 participant registers a guest and sees guest in players list', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Guest Admin', true);
-    const game = await createGame({ title: e2eTitle(testInfo, 'Guest Game'), createdById: admin.id, dateTime: daysFromNow(2) });
+    const participant = await createDevUserViaApi(request, testInfo, 'Guest Participant');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title: e2eTitle(testInfo, 'Guest Game'), dateTime: daysFromNow(2) });
     const guestName = `Guest ${Date.now().toString(36)}`;
 
-    await devLogin(page, testInfo, 'Guest Participant');
+    await switchToUser(page, participant);
     await page.goto(`/game/${game.id}`);
     await page.getByRole('button', { name: 'Add guest' }).click();
     await page.getByLabel('Guest Name:').fill(guestName);
@@ -166,9 +187,11 @@ test.describe('game details participant scenarios', () => {
 
   test('E2E-GAME-010 participant completes bring-ball flow', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Ball Admin', true);
-    const game = await createGame({ title: e2eTitle(testInfo, 'Bring Ball'), createdById: admin.id, dateTime: daysFromNow(2) });
+    const participant = await createDevUserViaApi(request, testInfo, 'Ball Participant');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title: e2eTitle(testInfo, 'Bring Ball'), dateTime: daysFromNow(2) });
 
-    await devLogin(page, testInfo, 'Ball Participant');
+    await switchToUser(page, participant);
     await page.goto(`/game/${game.id}`);
     await joinGame(page, true);
 

--- a/e2e/game-details-participant.spec.ts
+++ b/e2e/game-details-participant.spec.ts
@@ -1,0 +1,198 @@
+import { expect, test } from '@playwright/test';
+import {
+  cleanupE2eData,
+  createDevUserViaApi,
+  createGame,
+  daysFromNow,
+  devLogin,
+  e2eTitle,
+  registerUser,
+  waitForBackend,
+} from './support/fixtures';
+
+async function joinGame(page: import('@playwright/test').Page, bringBall = false) {
+  await page.getByRole('button', { name: 'Join Game' }).click();
+  await expect(page.getByRole('heading', { name: 'Will you bring a volleyball?' })).toBeVisible();
+  await page.getByRole('button', { name: bringBall ? /Yes, I'll bring one/ : /No, I won't bring one/ }).click();
+  await expect(page.getByText("You're in")).toBeVisible();
+}
+
+async function leaveGame(page: import('@playwright/test').Page) {
+  await page.getByRole('button', { name: 'Leave Game' }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await page.getByRole('dialog').getByRole('button', { name: 'Leave Game' }).click();
+  await expect(page.getByRole('button', { name: 'Join Game' })).toBeVisible();
+}
+
+test.describe('game details participant scenarios', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await cleanupE2eData();
+  });
+
+  test('E2E-GAME-001 participant sees upcoming game details and registration action', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Details Admin', true);
+    const title = e2eTitle(testInfo, 'Details Open');
+    const game = await createGame({
+      title,
+      createdById: admin.id,
+      dateTime: daysFromNow(2),
+      maxPlayers: 8,
+      paymentAmount: 750,
+      locationName: 'E2E Details Hall',
+    });
+
+    await devLogin(page, testInfo, 'Details Participant');
+    await page.goto(`/game/${game.id}`);
+
+    await expect(page.getByText(title)).toBeVisible();
+    await expect(page.getByRole('link', { name: 'E2E Details Hall' })).toBeVisible();
+    await expect(page.getByText('No players registered yet')).toBeVisible();
+    await expect(page.getByText('Be the first to join this game!')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Join Game' })).toBeVisible();
+  });
+
+  test('E2E-GAME-002 participant joins an open game and sees registered status', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Join Admin', true);
+    const game = await createGame({ title: e2eTitle(testInfo, 'Join Open'), createdById: admin.id, dateTime: daysFromNow(2) });
+
+    await devLogin(page, testInfo, 'Join Participant');
+    await page.goto(`/game/${game.id}`);
+    await joinGame(page);
+
+    await page.goto('/');
+    await expect(page.getByText("You're in")).toBeVisible();
+  });
+
+  test('E2E-GAME-003 participant leaves a joined game before the deadline', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Leave Admin', true);
+    const game = await createGame({ title: e2eTitle(testInfo, 'Leave Open'), createdById: admin.id, dateTime: daysFromNow(2) });
+
+    await devLogin(page, testInfo, 'Leave Participant');
+    await page.goto(`/game/${game.id}`);
+    await joinGame(page);
+    await leaveGame(page);
+
+    await expect(page.getByText("You're in")).toHaveCount(0);
+  });
+
+  test('E2E-GAME-004 participant joins a full game and lands on waiting list', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Full Admin', true);
+    const firstPlayer = await createDevUserViaApi(request, testInfo, 'Full First Player');
+    const game = await createGame({ title: e2eTitle(testInfo, 'Full Game'), createdById: admin.id, dateTime: daysFromNow(2), maxPlayers: 1 });
+    await registerUser(game.id, firstPlayer.id, new Date(Date.now() - 60_000));
+
+    await devLogin(page, testInfo, 'Full Waitlist Participant');
+    await page.goto(`/game/${game.id}`);
+    await joinGame(page);
+
+    await expect(page.getByText('Waiting List')).toBeVisible();
+    await expect(page.getByText('Waitlist')).toBeVisible();
+  });
+
+  test('E2E-GAME-005 leaving a full game promotes the next waitlisted participant', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Promote Admin', true);
+    const activePlayer = await devLogin(page, testInfo, 'Promote Active');
+    const waitlistedPlayer = await createDevUserViaApi(request, testInfo, 'Promote Waitlisted');
+    const game = await createGame({ title: e2eTitle(testInfo, 'Promote Waitlist'), createdById: admin.id, dateTime: daysFromNow(2), maxPlayers: 1 });
+    await registerUser(game.id, activePlayer.id, new Date(Date.now() - 60_000));
+    await registerUser(game.id, waitlistedPlayer.id, new Date());
+
+    await page.goto(`/game/${game.id}`);
+    await expect(page.getByText('Waiting List')).toBeVisible();
+    await leaveGame(page);
+
+    await expect(page.getByText('Waiting List')).toHaveCount(0);
+    await expect(page.getByText(waitlistedPlayer.displayName)).toBeVisible();
+  });
+
+  test('E2E-GAME-006 readonly game blocks participant self-registration', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Readonly Admin', true);
+    const game = await createGame({
+      title: e2eTitle(testInfo, 'Readonly Game'),
+      createdById: admin.id,
+      dateTime: daysFromNow(2),
+      readonly: true,
+    });
+
+    await devLogin(page, testInfo, 'Readonly Participant');
+    await page.goto(`/game/${game.id}`);
+
+    await expect(page.getByText('This game is readonly. Registration and deregistration are closed.')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Join Game' })).toHaveCount(0);
+  });
+
+  test('E2E-GAME-007 registered participant sees deadline info after unregister deadline passes', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Deadline Admin', true);
+    const participant = await devLogin(page, testInfo, 'Deadline Participant');
+    const game = await createGame({
+      title: e2eTitle(testInfo, 'Deadline Info'),
+      createdById: admin.id,
+      dateTime: daysFromNow(0, new Date().getHours() + 1),
+      unregisterDeadlineHours: 5,
+    });
+    await registerUser(game.id, participant.id, new Date());
+
+    await page.goto(`/game/${game.id}`);
+
+    await expect(page.getByText('You can only leave the game up to 5 hours before it starts.')).toBeVisible();
+  });
+
+  test('E2E-GAME-008 participant opens a non-existent game id and sees error recovery', async ({ page }, testInfo) => {
+    await devLogin(page, testInfo, 'Missing Game Participant');
+    await page.goto('/game/999999999');
+
+    await expect(page.getByRole('heading', { name: 'Error' })).toBeVisible();
+    await expect(page.getByText('Failed to load game details')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Back to Games' })).toBeVisible();
+  });
+
+  test('E2E-GAME-009 participant registers a guest and sees guest in players list', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Guest Admin', true);
+    const game = await createGame({ title: e2eTitle(testInfo, 'Guest Game'), createdById: admin.id, dateTime: daysFromNow(2) });
+    const guestName = `Guest ${Date.now().toString(36)}`;
+
+    await devLogin(page, testInfo, 'Guest Participant');
+    await page.goto(`/game/${game.id}`);
+    await page.getByRole('button', { name: 'Add guest' }).click();
+    await page.getByLabel('Guest Name:').fill(guestName);
+    await page.getByRole('button', { name: 'Register Guest' }).click();
+
+    await expect(page.getByText(guestName)).toBeVisible();
+    await expect(page.getByText(/Invited by E2E Guest Participant/)).toBeVisible();
+  });
+
+  test('E2E-GAME-010 participant completes bring-ball flow', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Ball Admin', true);
+    const game = await createGame({ title: e2eTitle(testInfo, 'Bring Ball'), createdById: admin.id, dateTime: daysFromNow(2) });
+
+    await devLogin(page, testInfo, 'Ball Participant');
+    await page.goto(`/game/${game.id}`);
+    await joinGame(page, true);
+
+    await expect(page.getByLabel('Bringing the ball')).toBeVisible();
+  });
+
+  test('E2E-GAME-011 seasonal game notes render without blocking core details', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Season Admin', true);
+    const seasonalGames = [
+      { tag: 'halloween' as const, note: 'Halloween Special' },
+      { tag: 'newyear' as const, note: 'New Year Special' },
+      { tag: 'march8' as const, note: 'March 8 Special' },
+    ];
+
+    await devLogin(page, testInfo, 'Season Participant');
+
+    for (const seasonal of seasonalGames) {
+      const game = await createGame({
+        title: e2eTitle(testInfo, `Season ${seasonal.tag}`),
+        createdById: admin.id,
+        dateTime: daysFromNow(2),
+        tag: seasonal.tag,
+      });
+      await page.goto(`/game/${game.id}`);
+      await expect(page.getByText(seasonal.note)).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Join Game' })).toBeVisible();
+    }
+  });
+});

--- a/e2e/game-details-participant.spec.ts
+++ b/e2e/game-details-participant.spec.ts
@@ -10,7 +10,7 @@ import {
   nextWeekday,
   registerForGameViaUi,
   switchToUser,
-  updateGame,
+  updateGameTag,
   waitForBackend,
 } from './support/fixtures';
 
@@ -213,7 +213,7 @@ test.describe('game details participant scenarios', () => {
         title: e2eTitle(testInfo, `Season ${seasonal.tag}`),
         dateTime: daysFromNow(2),
       });
-      await updateGame(game.id, { tag: seasonal.tag });
+      await updateGameTag(game.id, seasonal.tag);
       games.push({ game, note: seasonal.note });
     }
 

--- a/e2e/game-details-participant.spec.ts
+++ b/e2e/game-details-participant.spec.ts
@@ -72,6 +72,7 @@ test.describe('game details participant scenarios', () => {
     await devLogin(page, testInfo, 'Leave Participant');
     await page.goto(`/game/${game.id}`);
     await joinGame(page);
+    await page.waitForTimeout(1100);
     await leaveGame(page);
 
     await expect(page.getByText("You're in")).toHaveCount(0);

--- a/e2e/game-form.spec.ts
+++ b/e2e/game-form.spec.ts
@@ -6,7 +6,7 @@ import {
   devLogin,
   devLoginAs,
   e2eTitle,
-  findGameByTitle,
+  waitForAdminGameCreateResponse,
   waitForBackend,
 } from './support/fixtures';
 
@@ -45,13 +45,16 @@ test.describe('game creation and editing scenarios', () => {
     await devLogin(page, testInfo, 'Standard Create Admin', true);
     await page.goto('/games/new');
     await fillRequiredGameFields(page, title);
+    const createResponsePromise = waitForAdminGameCreateResponse(page);
     await page.getByRole('button', { name: 'Create Game' }).click();
+    const createResponse = await createResponsePromise;
+    expect(createResponse.ok()).toBeTruthy();
+    const { id } = (await createResponse.json()) as { id: number };
 
     await expect(page).toHaveURL('/');
-    const created = await findGameByTitle(title);
-    expect(created).toBeTruthy();
-    expect(created.location_name).toBe('E2E Form Hall');
-    expect(created.payment_amount).toBe(750);
+    await page.goto(`/game/${id}`);
+    await expect(page.getByRole('link', { name: 'E2E Form Hall' })).toBeVisible();
+    await expect(page.getByText('€7.50 per participant')).toBeVisible();
   });
 
   test('E2E-FORM-003 global admin previews total-cost pricing', async ({ page }, testInfo) => {
@@ -72,11 +75,15 @@ test.describe('game creation and editing scenarios', () => {
     await page.goto('/games/new');
     await fillRequiredGameFields(page, title);
     await setCheckbox(page, '#withPositions');
+    const createResponsePromise = waitForAdminGameCreateResponse(page);
     await page.getByRole('button', { name: 'Create Game' }).click();
-    await expect(page).toHaveURL('/');
+    const createResponse = await createResponsePromise;
+    expect(createResponse.ok()).toBeTruthy();
+    const { id } = (await createResponse.json()) as { id: number };
 
-    const created = await findGameByTitle(title);
-    expect(created.with_positions).toBe(true);
+    await expect(page).toHaveURL('/');
+    await page.goto(`/game/${id}/edit`);
+    await expect(page.locator('#withPositions')).toBeChecked();
   });
 
   test('E2E-FORM-005 global admin creates a readonly game that participants cannot self-register for', async ({ page, request }, testInfo) => {
@@ -87,15 +94,17 @@ test.describe('game creation and editing scenarios', () => {
     await page.goto('/games/new');
     await fillRequiredGameFields(page, title);
     await setCheckbox(page, '#readonly');
+    const createResponsePromise = waitForAdminGameCreateResponse(page);
     await page.getByRole('button', { name: 'Create Game' }).click();
-    await expect(page).toHaveURL('/');
+    const createResponse = await createResponsePromise;
+    expect(createResponse.ok()).toBeTruthy();
+    const { id } = (await createResponse.json()) as { id: number };
 
-    const created = await findGameByTitle(title);
-    expect(created.readonly).toBe(true);
+    await expect(page).toHaveURL('/');
 
     await page.getByRole('button', { name: 'Logout' }).click();
     await devLoginAs(page, participant);
-    await page.goto(`/game/${created.id}`);
+    await page.goto(`/game/${id}`);
     await expect(page.getByText('This game is readonly. Registration and deregistration are closed.')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Join Game' })).toHaveCount(0);
   });
@@ -109,7 +118,7 @@ test.describe('game creation and editing scenarios', () => {
     await page.getByRole('button', { name: 'Cancel' }).click();
 
     await expect(page).toHaveURL('/');
-    expect(await findGameByTitle(title)).toBeNull();
+    await expect(page.getByText(title)).toHaveCount(0);
   });
 
   test('E2E-FORM-007 global admin edits game settings and sees updated details', async ({ page, request }, testInfo) => {
@@ -119,9 +128,9 @@ test.describe('game creation and editing scenarios', () => {
 
     await devLoginAs(page, admin);
     const game = await createGameViaUi(page, { title: originalTitle });
-    await page.goto(`/game/${game.id}`);
-    await page.getByTitle('Edit Game Settings').click();
+    await page.goto(`/game/${game.id}/edit`);
     await expect(page.getByRole('heading', { name: 'Edit Game Settings' })).toBeVisible();
+    await expect(page.locator('#title')).toHaveValue(originalTitle);
 
     await page.locator('#title').fill(updatedTitle);
     await expect(page.locator('#title')).toHaveValue(updatedTitle);
@@ -160,6 +169,7 @@ test.describe('game creation and editing scenarios', () => {
     await page.getByRole('button', { name: 'Create Game' }).click();
 
     await expect(page.getByRole('heading', { name: 'Create New Game' })).toBeVisible();
-    expect(await findGameByTitle(title)).toBeNull();
+    await page.goto('/');
+    await expect(page.getByText(title)).toHaveCount(0);
   });
 });

--- a/e2e/game-form.spec.ts
+++ b/e2e/game-form.spec.ts
@@ -52,7 +52,7 @@ test.describe('game creation and editing scenarios', () => {
     await page.goto('/games/new');
 
     await page.locator('#maxPlayers').fill('10');
-    await page.locator('#pricingMode').check();
+    await page.locator('#pricingMode').check({ force: true });
     await page.locator('#paymentAmount').fill('100');
 
     await expect(page.getByText('€100 ÷ 10 players = €10.00 per player')).toBeVisible();
@@ -64,7 +64,7 @@ test.describe('game creation and editing scenarios', () => {
     await devLogin(page, testInfo, 'Five One Admin', true);
     await page.goto('/games/new');
     await fillRequiredGameFields(page, title);
-    await page.locator('#withPositions').check();
+    await page.locator('#withPositions').check({ force: true });
     await page.getByRole('button', { name: 'Create Game' }).click();
 
     const created = await findGameByTitle(title);
@@ -77,7 +77,7 @@ test.describe('game creation and editing scenarios', () => {
     await devLogin(page, testInfo, 'Priority Create Admin', true);
     await page.goto('/games/new');
     await fillRequiredGameFields(page, title);
-    await page.locator('#withPriorityPlayers').check();
+    await page.locator('#withPriorityPlayers').check({ force: true });
     await page.getByRole('button', { name: 'Create Game' }).click();
 
     const created = await findGameByTitle(title);
@@ -91,7 +91,7 @@ test.describe('game creation and editing scenarios', () => {
     await devLogin(page, testInfo, 'Readonly Create Admin', true);
     await page.goto('/games/new');
     await fillRequiredGameFields(page, title);
-    await page.locator('#readonly').check();
+    await page.locator('#readonly').check({ force: true });
     await page.getByRole('button', { name: 'Create Game' }).click();
 
     const created = await findGameByTitle(title);

--- a/e2e/game-form.spec.ts
+++ b/e2e/game-form.spec.ts
@@ -79,21 +79,7 @@ test.describe('game creation and editing scenarios', () => {
     expect(created.with_positions).toBe(true);
   });
 
-  test('E2E-FORM-005 global admin creates a priority-player game', async ({ page }, testInfo) => {
-    const title = e2eTitle(testInfo, 'Priority Create');
-
-    await devLogin(page, testInfo, 'Priority Create Admin', true);
-    await page.goto('/games/new');
-    await fillRequiredGameFields(page, title);
-    await setCheckbox(page, '#withPriorityPlayers');
-    await page.getByRole('button', { name: 'Create Game' }).click();
-    await expect(page).toHaveURL('/');
-
-    const created = await findGameByTitle(title);
-    expect(created.with_priority_players).toBe(true);
-  });
-
-  test('E2E-FORM-006 global admin creates a readonly game that participants cannot self-register for', async ({ page, request }, testInfo) => {
+  test('E2E-FORM-005 global admin creates a readonly game that participants cannot self-register for', async ({ page, request }, testInfo) => {
     const title = e2eTitle(testInfo, 'Readonly Create');
     const participant = await createDevUserViaApi(request, testInfo, 'Readonly Created Participant');
 
@@ -114,7 +100,7 @@ test.describe('game creation and editing scenarios', () => {
     await expect(page.getByRole('button', { name: 'Join Game' })).toHaveCount(0);
   });
 
-  test('E2E-FORM-007 global admin cancels game creation without creating a game', async ({ page }, testInfo) => {
+  test('E2E-FORM-006 global admin cancels game creation without creating a game', async ({ page }, testInfo) => {
     const title = e2eTitle(testInfo, 'Cancelled Create');
 
     await devLogin(page, testInfo, 'Cancel Create Admin', true);
@@ -126,7 +112,7 @@ test.describe('game creation and editing scenarios', () => {
     expect(await findGameByTitle(title)).toBeNull();
   });
 
-  test('E2E-FORM-008 global admin edits game settings and sees updated details', async ({ page, request }, testInfo) => {
+  test('E2E-FORM-007 global admin edits game settings and sees updated details', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Edit Admin', true);
     const originalTitle = e2eTitle(testInfo, 'Edit Original');
     const updatedTitle = e2eTitle(testInfo, 'Edit Updated');
@@ -147,7 +133,7 @@ test.describe('game creation and editing scenarios', () => {
     await expect(page.getByRole('link', { name: 'E2E Edited Hall' })).toBeVisible();
   });
 
-  test('E2E-FORM-009 global admin cancels editing without persisting changes', async ({ page, request }, testInfo) => {
+  test('E2E-FORM-008 global admin cancels editing without persisting changes', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Cancel Edit Admin', true);
     const originalTitle = e2eTitle(testInfo, 'Cancel Edit Original');
     const cancelledTitle = e2eTitle(testInfo, 'Cancel Edit New');
@@ -163,7 +149,7 @@ test.describe('game creation and editing scenarios', () => {
     await expect(page.getByText(cancelledTitle)).toHaveCount(0);
   });
 
-  test('E2E-FORM-010 invalid numeric bounds prevent game creation', async ({ page }, testInfo) => {
+  test('E2E-FORM-009 invalid numeric bounds prevent game creation', async ({ page }, testInfo) => {
     const title = e2eTitle(testInfo, 'Invalid Create');
 
     await devLogin(page, testInfo, 'Invalid Create Admin', true);

--- a/e2e/game-form.spec.ts
+++ b/e2e/game-form.spec.ts
@@ -73,6 +73,7 @@ test.describe('game creation and editing scenarios', () => {
     await fillRequiredGameFields(page, title);
     await setCheckbox(page, '#withPositions');
     await page.getByRole('button', { name: 'Create Game' }).click();
+    await expect(page).toHaveURL('/');
 
     const created = await findGameByTitle(title);
     expect(created.with_positions).toBe(true);
@@ -86,6 +87,7 @@ test.describe('game creation and editing scenarios', () => {
     await fillRequiredGameFields(page, title);
     await setCheckbox(page, '#withPriorityPlayers');
     await page.getByRole('button', { name: 'Create Game' }).click();
+    await expect(page).toHaveURL('/');
 
     const created = await findGameByTitle(title);
     expect(created.with_priority_players).toBe(true);
@@ -100,6 +102,7 @@ test.describe('game creation and editing scenarios', () => {
     await fillRequiredGameFields(page, title);
     await setCheckbox(page, '#readonly');
     await page.getByRole('button', { name: 'Create Game' }).click();
+    await expect(page).toHaveURL('/');
 
     const created = await findGameByTitle(title);
     expect(created.readonly).toBe(true);

--- a/e2e/game-form.spec.ts
+++ b/e2e/game-form.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import {
   cleanupE2eData,
   createDevUserViaApi,
-  createGame,
+  createGameViaUi,
   devLogin,
   devLoginAs,
   e2eTitle,
@@ -116,14 +116,15 @@ test.describe('game creation and editing scenarios', () => {
     const admin = await createDevUserViaApi(request, testInfo, 'Edit Admin', true);
     const originalTitle = e2eTitle(testInfo, 'Edit Original');
     const updatedTitle = e2eTitle(testInfo, 'Edit Updated');
-    const game = await createGame({ title: originalTitle, createdById: admin.id });
 
     await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title: originalTitle });
     await page.goto(`/game/${game.id}`);
     await page.getByTitle('Edit Game Settings').click();
     await expect(page.getByRole('heading', { name: 'Edit Game Settings' })).toBeVisible();
 
     await page.locator('#title').fill(updatedTitle);
+    await expect(page.locator('#title')).toHaveValue(updatedTitle);
     await page.locator('#locationName').fill('E2E Edited Hall');
     await page.locator('#maxPlayers').fill('16');
     await page.getByRole('button', { name: 'Save Changes' }).click();
@@ -137,9 +138,9 @@ test.describe('game creation and editing scenarios', () => {
     const admin = await createDevUserViaApi(request, testInfo, 'Cancel Edit Admin', true);
     const originalTitle = e2eTitle(testInfo, 'Cancel Edit Original');
     const cancelledTitle = e2eTitle(testInfo, 'Cancel Edit New');
-    const game = await createGame({ title: originalTitle, createdById: admin.id });
 
     await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title: originalTitle });
     await page.goto(`/game/${game.id}/edit`);
     await page.locator('#title').fill(cancelledTitle);
     await page.getByRole('button', { name: 'Cancel' }).click();

--- a/e2e/game-form.spec.ts
+++ b/e2e/game-form.spec.ts
@@ -1,0 +1,168 @@
+import { expect, test } from '@playwright/test';
+import {
+  cleanupE2eData,
+  createDevUserViaApi,
+  createGame,
+  devLogin,
+  devLoginAs,
+  e2eTitle,
+  findGameByTitle,
+  waitForBackend,
+} from './support/fixtures';
+
+async function fillRequiredGameFields(page: import('@playwright/test').Page, title: string) {
+  await page.locator('#maxPlayers').fill('12');
+  await page.locator('#unregisterDeadlineHours').fill('5');
+  await page.locator('#paymentAmount').fill('7.50');
+  await page.locator('#locationName').fill('E2E Form Hall');
+  await page.locator('#locationLink').fill('https://maps.example/e2e-form-hall');
+  await page.locator('#title').fill(title);
+}
+
+test.describe('game creation and editing scenarios', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await cleanupE2eData();
+  });
+
+  test('E2E-FORM-001 global admin opens Create New Game from games home', async ({ page }, testInfo) => {
+    await devLogin(page, testInfo, 'Open Form Admin', true);
+    await page.getByTitle('Create New Game').click();
+
+    await expect(page.getByRole('heading', { name: 'Create New Game' })).toBeVisible();
+  });
+
+  test('E2E-FORM-002 global admin creates a standard game', async ({ page }, testInfo) => {
+    const title = e2eTitle(testInfo, 'Standard Create');
+
+    await devLogin(page, testInfo, 'Standard Create Admin', true);
+    await page.goto('/games/new');
+    await fillRequiredGameFields(page, title);
+    await page.getByRole('button', { name: 'Create Game' }).click();
+
+    await expect(page).toHaveURL('/');
+    const created = await findGameByTitle(title);
+    expect(created).toBeTruthy();
+    expect(created.location_name).toBe('E2E Form Hall');
+    expect(created.payment_amount).toBe(750);
+  });
+
+  test('E2E-FORM-003 global admin previews total-cost pricing', async ({ page }, testInfo) => {
+    await devLogin(page, testInfo, 'Total Cost Admin', true);
+    await page.goto('/games/new');
+
+    await page.locator('#maxPlayers').fill('10');
+    await page.locator('#pricingMode').check();
+    await page.locator('#paymentAmount').fill('100');
+
+    await expect(page.getByText('€100 ÷ 10 players = €10.00 per player')).toBeVisible();
+  });
+
+  test('E2E-FORM-004 global admin creates a Playing 5-1 game', async ({ page }, testInfo) => {
+    const title = e2eTitle(testInfo, 'Five One Create');
+
+    await devLogin(page, testInfo, 'Five One Admin', true);
+    await page.goto('/games/new');
+    await fillRequiredGameFields(page, title);
+    await page.locator('#withPositions').check();
+    await page.getByRole('button', { name: 'Create Game' }).click();
+
+    const created = await findGameByTitle(title);
+    expect(created.with_positions).toBe(true);
+  });
+
+  test('E2E-FORM-005 global admin creates a priority-player game', async ({ page }, testInfo) => {
+    const title = e2eTitle(testInfo, 'Priority Create');
+
+    await devLogin(page, testInfo, 'Priority Create Admin', true);
+    await page.goto('/games/new');
+    await fillRequiredGameFields(page, title);
+    await page.locator('#withPriorityPlayers').check();
+    await page.getByRole('button', { name: 'Create Game' }).click();
+
+    const created = await findGameByTitle(title);
+    expect(created.with_priority_players).toBe(true);
+  });
+
+  test('E2E-FORM-006 global admin creates a readonly game that participants cannot self-register for', async ({ page, request }, testInfo) => {
+    const title = e2eTitle(testInfo, 'Readonly Create');
+    const participant = await createDevUserViaApi(request, testInfo, 'Readonly Created Participant');
+
+    await devLogin(page, testInfo, 'Readonly Create Admin', true);
+    await page.goto('/games/new');
+    await fillRequiredGameFields(page, title);
+    await page.locator('#readonly').check();
+    await page.getByRole('button', { name: 'Create Game' }).click();
+
+    const created = await findGameByTitle(title);
+    expect(created.readonly).toBe(true);
+
+    await page.getByRole('button', { name: 'Logout' }).click();
+    await devLoginAs(page, participant);
+    await page.goto(`/game/${created.id}`);
+    await expect(page.getByText('This game is readonly. Registration and deregistration are closed.')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Join Game' })).toHaveCount(0);
+  });
+
+  test('E2E-FORM-007 global admin cancels game creation without creating a game', async ({ page }, testInfo) => {
+    const title = e2eTitle(testInfo, 'Cancelled Create');
+
+    await devLogin(page, testInfo, 'Cancel Create Admin', true);
+    await page.goto('/games/new');
+    await fillRequiredGameFields(page, title);
+    await page.getByRole('button', { name: 'Cancel' }).click();
+
+    await expect(page).toHaveURL('/');
+    expect(await findGameByTitle(title)).toBeNull();
+  });
+
+  test('E2E-FORM-008 global admin edits game settings and sees updated details', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Edit Admin', true);
+    const originalTitle = e2eTitle(testInfo, 'Edit Original');
+    const updatedTitle = e2eTitle(testInfo, 'Edit Updated');
+    const game = await createGame({ title: originalTitle, createdById: admin.id });
+
+    await devLoginAs(page, admin);
+    await page.goto(`/game/${game.id}`);
+    await page.getByTitle('Edit Game Settings').click();
+    await expect(page.getByRole('heading', { name: 'Edit Game Settings' })).toBeVisible();
+
+    await page.locator('#title').fill(updatedTitle);
+    await page.locator('#locationName').fill('E2E Edited Hall');
+    await page.locator('#maxPlayers').fill('16');
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/game/${game.id}$`));
+    await expect(page.getByText(updatedTitle)).toBeVisible();
+    await expect(page.getByRole('link', { name: 'E2E Edited Hall' })).toBeVisible();
+  });
+
+  test('E2E-FORM-009 global admin cancels editing without persisting changes', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Cancel Edit Admin', true);
+    const originalTitle = e2eTitle(testInfo, 'Cancel Edit Original');
+    const cancelledTitle = e2eTitle(testInfo, 'Cancel Edit New');
+    const game = await createGame({ title: originalTitle, createdById: admin.id });
+
+    await devLoginAs(page, admin);
+    await page.goto(`/game/${game.id}/edit`);
+    await page.locator('#title').fill(cancelledTitle);
+    await page.getByRole('button', { name: 'Cancel' }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/game/${game.id}$`));
+    await expect(page.getByText(originalTitle)).toBeVisible();
+    await expect(page.getByText(cancelledTitle)).toHaveCount(0);
+  });
+
+  test('E2E-FORM-010 invalid numeric bounds prevent game creation', async ({ page }, testInfo) => {
+    const title = e2eTitle(testInfo, 'Invalid Create');
+
+    await devLogin(page, testInfo, 'Invalid Create Admin', true);
+    await page.goto('/games/new');
+    await fillRequiredGameFields(page, title);
+    await page.locator('#maxPlayers').fill('1');
+    await page.getByRole('button', { name: 'Create Game' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Create New Game' })).toBeVisible();
+    expect(await findGameByTitle(title)).toBeNull();
+  });
+});

--- a/e2e/game-form.spec.ts
+++ b/e2e/game-form.spec.ts
@@ -3,10 +3,16 @@ import {
   cleanupE2eData,
   createDevUserViaApi,
   createGameViaUi,
+  daysFromNow,
   devLogin,
   devLoginAs,
+  enableBunqIntegrationViaUi,
   e2eTitle,
+  moveGameToPastViaUi,
+  resetBunqMock,
+  sendPaymentRequestsViaUi,
   waitForAdminGameCreateResponse,
+  waitForAdminGameUpdateResponse,
   waitForBackend,
 } from './support/fixtures';
 
@@ -171,5 +177,37 @@ test.describe('game creation and editing scenarios', () => {
     await expect(page.getByRole('heading', { name: 'Create New Game' })).toBeVisible();
     await page.goto('/');
     await expect(page.getByText(title)).toHaveCount(0);
+  });
+
+  test('E2E-FORM-010 global admin edits game metadata after payment requests were sent', async ({ page, request }, testInfo) => {
+    await resetBunqMock();
+
+    const admin = await createDevUserViaApi(request, testInfo, 'Post Pay Edit Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Post Pay Edit Participant');
+    const originalTitle = e2eTitle(testInfo, 'Post Pay Original');
+    const updatedTitle = e2eTitle(testInfo, 'Post Pay Updated');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title: originalTitle, dateTime: daysFromNow(2) });
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await page.locator('.admin-actions').getByRole('button', { name: 'Add Participant' }).click();
+    await page.getByPlaceholder('Search users to add...').fill(participant.displayName);
+    await page.getByText(participant.displayName, { exact: true }).click();
+    await sendPaymentRequestsViaUi(page);
+    await expect(page.getByTitle('Add Participant')).toHaveCount(0);
+
+    await page.getByTitle('Edit Game Settings').click();
+    await expect(page.getByRole('heading', { name: 'Edit Game Settings' })).toBeVisible();
+    await page.locator('#title').fill(updatedTitle);
+    const updatePromise = waitForAdminGameUpdateResponse(page, game.id);
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+    await updatePromise;
+
+    await expect(page).toHaveURL(new RegExp(`/game/${game.id}$`));
+    await expect(page.getByText(updatedTitle)).toBeVisible();
+    await expect(page.getByText(originalTitle)).toHaveCount(0);
   });
 });

--- a/e2e/game-form.spec.ts
+++ b/e2e/game-form.spec.ts
@@ -20,11 +20,10 @@ async function fillRequiredGameFields(page: import('@playwright/test').Page, tit
 }
 
 async function setCheckbox(page: import('@playwright/test').Page, selector: string, checked = true) {
-  await page.locator(selector).evaluate((element, value) => {
-    const input = element as HTMLInputElement;
-    input.checked = value;
-    input.dispatchEvent(new Event('change', { bubbles: true }));
-  }, checked);
+  const input = page.locator(selector);
+  if ((await input.isChecked()) !== checked) {
+    await page.locator(`label[for="${selector.replace('#', '')}"]`).click();
+  }
 }
 
 test.describe('game creation and editing scenarios', () => {

--- a/e2e/game-form.spec.ts
+++ b/e2e/game-form.spec.ts
@@ -19,6 +19,14 @@ async function fillRequiredGameFields(page: import('@playwright/test').Page, tit
   await page.locator('#title').fill(title);
 }
 
+async function setCheckbox(page: import('@playwright/test').Page, selector: string, checked = true) {
+  await page.locator(selector).evaluate((element, value) => {
+    const input = element as HTMLInputElement;
+    input.checked = value;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  }, checked);
+}
+
 test.describe('game creation and editing scenarios', () => {
   test.beforeEach(async ({ request }) => {
     await waitForBackend(request);
@@ -52,7 +60,7 @@ test.describe('game creation and editing scenarios', () => {
     await page.goto('/games/new');
 
     await page.locator('#maxPlayers').fill('10');
-    await page.locator('#pricingMode').check({ force: true });
+    await setCheckbox(page, '#pricingMode');
     await page.locator('#paymentAmount').fill('100');
 
     await expect(page.getByText('€100 ÷ 10 players = €10.00 per player')).toBeVisible();
@@ -64,7 +72,7 @@ test.describe('game creation and editing scenarios', () => {
     await devLogin(page, testInfo, 'Five One Admin', true);
     await page.goto('/games/new');
     await fillRequiredGameFields(page, title);
-    await page.locator('#withPositions').check({ force: true });
+    await setCheckbox(page, '#withPositions');
     await page.getByRole('button', { name: 'Create Game' }).click();
 
     const created = await findGameByTitle(title);
@@ -77,7 +85,7 @@ test.describe('game creation and editing scenarios', () => {
     await devLogin(page, testInfo, 'Priority Create Admin', true);
     await page.goto('/games/new');
     await fillRequiredGameFields(page, title);
-    await page.locator('#withPriorityPlayers').check({ force: true });
+    await setCheckbox(page, '#withPriorityPlayers');
     await page.getByRole('button', { name: 'Create Game' }).click();
 
     const created = await findGameByTitle(title);
@@ -91,7 +99,7 @@ test.describe('game creation and editing scenarios', () => {
     await devLogin(page, testInfo, 'Readonly Create Admin', true);
     await page.goto('/games/new');
     await fillRequiredGameFields(page, title);
-    await page.locator('#readonly').check({ force: true });
+    await setCheckbox(page, '#readonly');
     await page.getByRole('button', { name: 'Create Game' }).click();
 
     const created = await findGameByTitle(title);

--- a/e2e/games-home.spec.ts
+++ b/e2e/games-home.spec.ts
@@ -83,7 +83,7 @@ test.describe('games home scenarios', () => {
     await page.goto('/');
 
     await expect(page.getByText(title)).toBeVisible();
-    await expect(page.getByText('Waitlist')).toBeVisible();
+    await expect(page.getByText('Waitlist', { exact: true })).toBeVisible();
   });
 
   test('E2E-HOME-006 location link opens externally without changing app route', async ({ page, request }, testInfo) => {
@@ -94,7 +94,7 @@ test.describe('games home scenarios', () => {
       createdById: admin.id,
       dateTime: nextWeekday(0),
       locationName: 'E2E Maps Gym',
-      locationLink: 'https://maps.example/e2e-gym',
+      locationLink: 'https://example.com/e2e-gym',
     });
 
     await devLogin(page, testInfo, 'Location Participant');
@@ -103,7 +103,7 @@ test.describe('games home scenarios', () => {
     const popup = await popupPromise;
 
     await expect(page).toHaveURL('/');
-    await expect(popup).toHaveURL(/maps\.example\/e2e-gym/);
+    expect(popup.url()).toContain('example.com/e2e-gym');
     await popup.close();
   });
 

--- a/e2e/games-home.spec.ts
+++ b/e2e/games-home.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test';
 import {
   cleanupE2eData,
   createDevUserViaApi,
-  createGame,
   createGameViaUi,
   daysFromNow,
   devLogin,
@@ -11,6 +10,7 @@ import {
   nextWeekday,
   registerForGameViaUi,
   switchToUser,
+  updateGame,
   waitForBackend,
 } from './support/fixtures';
 
@@ -154,9 +154,9 @@ test.describe('games home scenarios', () => {
   test('E2E-HOME-009 global admin toggles Show fully paid games', async ({ page, request }, testInfo) => {
     const adminUser = await createDevUserViaApi(request, testInfo, 'Fully Paid Admin', true);
     const title = e2eTitle(testInfo, 'Fully Paid Past');
-    await createGame({ title, createdById: adminUser.id, dateTime: daysFromNow(-1), fullyPaid: true });
-
     await devLoginAs(page, adminUser);
+    const game = await createGameViaUi(page, { title, dateTime: daysFromNow(-1) });
+    await updateGame(game.id, { fully_paid: true });
     await page.getByLabel('Past').check();
     await expect(page.getByText(title)).toHaveCount(0);
     await page.getByLabel('Show fully paid games').check();

--- a/e2e/games-home.spec.ts
+++ b/e2e/games-home.spec.ts
@@ -1,18 +1,29 @@
 import { expect, test } from '@playwright/test';
 import {
   cleanupE2eData,
-  createAdminAssignment,
   createDevUserViaApi,
   createGame,
+  createGameViaUi,
   daysFromNow,
   devLogin,
   devLoginAs,
   e2eTitle,
   nextWeekday,
-  registerUser,
-  updateGame,
+  registerForGameViaUi,
+  switchToUser,
   waitForBackend,
 } from './support/fixtures';
+
+async function createAdminAssignmentViaUi(page: import('@playwright/test').Page, userDisplayName: string) {
+  await page.goto('/game-administrators');
+  await expect(page.getByRole('heading', { name: 'Game Administrators' })).toBeVisible();
+  await page.getByRole('button', { name: 'Add Assignment' }).click();
+  await page.getByLabel('Day of Week').selectOption('6');
+  await page.getByPlaceholder('Search for a user...').fill(userDisplayName);
+  await page.getByText(userDisplayName).click();
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(page.getByText(userDisplayName)).toBeVisible();
+}
 
 test.describe('games home scenarios', () => {
   test.beforeEach(async ({ request }) => {
@@ -22,20 +33,24 @@ test.describe('games home scenarios', () => {
 
   test('E2E-HOME-001 participant sees an upcoming game on the games home', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Home Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Home Participant');
     const title = e2eTitle(testInfo, 'Home Upcoming');
-    await createGame({ title, createdById: admin.id, dateTime: nextWeekday(0), maxPlayers: 12 });
+    await devLoginAs(page, admin);
+    await createGameViaUi(page, { title, dateTime: nextWeekday(0), maxPlayers: 12 });
 
-    await devLogin(page, testInfo, 'Home Participant');
+    await switchToUser(page, participant);
 
     await expect(page.getByText(title)).toBeVisible();
   });
 
   test('E2E-HOME-002 participant opens a game card and reaches details', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Card Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Card Participant');
     const title = e2eTitle(testInfo, 'Open Card');
-    await createGame({ title, createdById: admin.id, dateTime: nextWeekday(0) });
+    await devLoginAs(page, admin);
+    await createGameViaUi(page, { title, dateTime: nextWeekday(0) });
 
-    await devLogin(page, testInfo, 'Card Participant');
+    await switchToUser(page, participant);
     await page.getByText(title).click();
 
     await expect(page).toHaveURL(/\/game\/\d+/);
@@ -44,14 +59,15 @@ test.describe('games home scenarios', () => {
 
   test('E2E-HOME-003 category multi-select shows selected category information', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Category Admin', true);
-    await createGame({
+    const participant = await createDevUserViaApi(request, testInfo, 'Category Participant');
+    await devLoginAs(page, admin);
+    await createGameViaUi(page, {
       title: e2eTitle(testInfo, 'Thursday Five One'),
-      createdById: admin.id,
       dateTime: nextWeekday(4),
       withPositions: true,
     });
 
-    await devLogin(page, testInfo, 'Category Participant');
+    await switchToUser(page, participant);
     await page.locator('.category-multiselect-trigger').click();
     await page.getByText('Thursday 5-1').click();
 
@@ -60,10 +76,11 @@ test.describe('games home scenarios', () => {
 
   test('E2E-HOME-004 registered participant sees You are in badge', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Registered Admin', true);
-    const participant = await devLogin(page, testInfo, 'Registered Participant');
+    const participant = await createDevUserViaApi(request, testInfo, 'Registered Participant');
     const title = e2eTitle(testInfo, 'Registered Badge');
-    const game = await createGame({ title, createdById: admin.id, dateTime: nextWeekday(0) });
-    await registerUser(game.id, participant.id, new Date());
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title, dateTime: nextWeekday(0) });
+    await registerForGameViaUi(page, participant, game.id);
 
     await page.goto('/');
 
@@ -74,11 +91,14 @@ test.describe('games home scenarios', () => {
   test('E2E-HOME-005 waitlisted participant sees Waitlist badge', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Waitlist Admin', true);
     const firstPlayer = await createDevUserViaApi(request, testInfo, 'First Player');
-    const participant = await devLogin(page, testInfo, 'Waitlist Participant');
+    const secondPlayer = await createDevUserViaApi(request, testInfo, 'Second Player');
+    const participant = await createDevUserViaApi(request, testInfo, 'Waitlist Participant');
     const title = e2eTitle(testInfo, 'Waitlist Badge');
-    const game = await createGame({ title, createdById: admin.id, dateTime: nextWeekday(0), maxPlayers: 1 });
-    await registerUser(game.id, firstPlayer.id, new Date(Date.now() - 60_000));
-    await registerUser(game.id, participant.id, new Date());
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, { title, dateTime: nextWeekday(0), maxPlayers: 2 });
+    await registerForGameViaUi(page, firstPlayer, game.id);
+    await registerForGameViaUi(page, secondPlayer, game.id);
+    await registerForGameViaUi(page, participant, game.id, 'Waitlist');
 
     await page.goto('/');
 
@@ -88,16 +108,17 @@ test.describe('games home scenarios', () => {
 
   test('E2E-HOME-006 location link opens externally without changing app route', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Location Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Location Participant');
     const title = e2eTitle(testInfo, 'Location Card');
-    await createGame({
+    await devLoginAs(page, admin);
+    await createGameViaUi(page, {
       title,
-      createdById: admin.id,
       dateTime: nextWeekday(0),
       locationName: 'E2E Maps Gym',
       locationLink: 'https://example.com/e2e-gym',
     });
 
-    await devLogin(page, testInfo, 'Location Participant');
+    await switchToUser(page, participant);
     const popupPromise = page.waitForEvent('popup');
     await page.getByRole('link', { name: /E2E Maps Gym/ }).click();
     const popup = await popupPromise;
@@ -110,9 +131,8 @@ test.describe('games home scenarios', () => {
   test('E2E-HOME-007 global admin switches between Upcoming and Past filters', async ({ page, request }, testInfo) => {
     const title = e2eTitle(testInfo, 'Past Filter');
     const adminUser = await createDevUserViaApi(request, testInfo, 'Past Filter Admin', true);
-    await createGame({ title, createdById: adminUser.id, dateTime: daysFromNow(-1) });
-
     await devLoginAs(page, adminUser);
+    await createGameViaUi(page, { title, dateTime: daysFromNow(-1) });
     await page.getByLabel('Past').check();
 
     await expect(page.getByText(title)).toBeVisible();
@@ -123,9 +143,8 @@ test.describe('games home scenarios', () => {
   test('E2E-HOME-008 global admin toggles Show all scheduled games', async ({ page, request }, testInfo) => {
     const adminUser = await createDevUserViaApi(request, testInfo, 'Show All Admin', true);
     const title = e2eTitle(testInfo, 'Far Future');
-    await createGame({ title, createdById: adminUser.id, dateTime: nextWeekday(0, 21) });
-
     await devLoginAs(page, adminUser);
+    await createGameViaUi(page, { title, dateTime: nextWeekday(0, 21) });
     await expect(page.getByText(title)).toHaveCount(0);
     await page.getByLabel('Show all scheduled games').check();
 
@@ -153,10 +172,12 @@ test.describe('games home scenarios', () => {
   });
 
   test('E2E-HOME-011 assigned admin sees create access without global admin links', async ({ page, request }, testInfo) => {
+    const globalAdmin = await createDevUserViaApi(request, testInfo, 'Assignment Home Creator', true);
     const assignedAdmin = await createDevUserViaApi(request, testInfo, 'Assigned Home Admin');
-    await createAdminAssignment(6, false, assignedAdmin.id);
+    await devLoginAs(page, globalAdmin);
+    await createAdminAssignmentViaUi(page, assignedAdmin.displayName);
 
-    await devLoginAs(page, assignedAdmin);
+    await switchToUser(page, assignedAdmin);
 
     await expect(page.getByTitle('Create New Game')).toBeVisible();
     await expect(page.getByTitle('Game Administrators')).toHaveCount(0);

--- a/e2e/games-home.spec.ts
+++ b/e2e/games-home.spec.ts
@@ -6,9 +6,13 @@ import {
   daysFromNow,
   devLogin,
   devLoginAs,
+  enableBunqIntegrationViaUi,
   e2eTitle,
+  moveGameToPastViaUi,
   nextWeekday,
   registerForGameViaUi,
+  resetBunqMock,
+  sendPaymentRequestsViaUi,
   switchToUser,
   updateGame,
   waitForBackend,
@@ -256,5 +260,46 @@ test.describe('games home scenarios', () => {
     await page.locator('label.category-multiselect-option').filter({ hasText: 'Sunday' }).click();
 
     await expect(page.getByText('No games available')).toBeVisible();
+  });
+
+  test('E2E-HOME-015 participant sees unpaid games block and Pay now opens payment link', async ({
+    page,
+    request,
+  }, testInfo) => {
+    await resetBunqMock();
+
+    const admin = await createDevUserViaApi(request, testInfo, 'Unpaid Home Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Unpaid Home Participant');
+    const locationName = 'E2E Unpaid Home Hall';
+    const title = e2eTitle(testInfo, 'Unpaid Home Game');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title,
+      dateTime: daysFromNow(2),
+      locationName,
+    });
+
+    await registerForGameViaUi(page, participant, game.id);
+
+    await switchToUser(page, admin);
+    await moveGameToPastViaUi(page, game.id);
+    await enableBunqIntegrationViaUi(page);
+
+    await page.goto(`/game/${game.id}`);
+    await sendPaymentRequestsViaUi(page);
+
+    await switchToUser(page, participant);
+    await page.goto('/');
+
+    await expect(page.getByText('Your unpaid games')).toBeVisible();
+    const unpaidItem = page.locator('.unpaid-item').filter({ hasText: locationName });
+    await expect(unpaidItem).toBeVisible();
+
+    const popupPromise = page.waitForEvent('popup');
+    await unpaidItem.getByRole('button', { name: 'Pay now' }).click();
+    const popup = await popupPromise;
+    await expect(popup).toHaveURL(/bunq\.me\/e2e-mock/);
+    await popup.close();
   });
 });

--- a/e2e/games-home.spec.ts
+++ b/e2e/games-home.spec.ts
@@ -14,13 +14,31 @@ import {
   waitForBackend,
 } from './support/fixtures';
 
-async function createAdminAssignmentViaUi(page: import('@playwright/test').Page, userDisplayName: string) {
+type AdminAssignmentViaUiOptions = {
+  dayOptionValue?: string;
+  withPositions?: boolean;
+};
+
+async function createAdminAssignmentViaUi(
+  page: import('@playwright/test').Page,
+  userDisplayName: string,
+  options?: AdminAssignmentViaUiOptions
+) {
+  const dayOptionValue = options?.dayOptionValue ?? '6';
+  const withPositions = options?.withPositions ?? false;
+
   await page.goto('/game-administrators');
   await expect(page.getByRole('heading', { name: 'Game Administrators' })).toBeVisible();
   await page.getByRole('button', { name: 'Add Assignment' }).click();
-  await page.getByLabel('Day of Week').selectOption('6');
+  await page.getByLabel('Day of Week').selectOption(dayOptionValue);
+  const positionsCheckbox = page.getByRole('checkbox', { name: /5-1 positions game/i });
+  if (withPositions) {
+    await positionsCheckbox.check();
+  } else {
+    await positionsCheckbox.uncheck();
+  }
   await page.getByPlaceholder('Search for a user...').fill(userDisplayName);
-  await page.getByText(userDisplayName).click();
+  await page.getByText(userDisplayName, { exact: true }).click();
   await page.getByRole('button', { name: 'Create' }).click();
   await expect(page.getByText(userDisplayName)).toBeVisible();
 }

--- a/e2e/games-home.spec.ts
+++ b/e2e/games-home.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import {
+  addParticipantViaUi,
   cleanupE2eData,
   createDevUserViaApi,
   createGameViaUi,
@@ -10,11 +11,11 @@ import {
   e2eTitle,
   moveGameToPastViaUi,
   nextWeekday,
+  markGameFullyPaidViaBunq,
   registerForGameViaUi,
   resetBunqMock,
   sendPaymentRequestsViaUi,
   switchToUser,
-  updateGame,
   waitForBackend,
 } from './support/fixtures';
 
@@ -175,10 +176,17 @@ test.describe('games home scenarios', () => {
 
   test('E2E-HOME-009 global admin toggles Show fully paid games', async ({ page, request }, testInfo) => {
     const adminUser = await createDevUserViaApi(request, testInfo, 'Fully Paid Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Fully Paid Participant');
     const title = e2eTitle(testInfo, 'Fully Paid Past');
     await devLoginAs(page, adminUser);
-    const game = await createGameViaUi(page, { title, dateTime: daysFromNow(-1) });
-    await updateGame(game.id, { fully_paid: true });
+    const game = await createGameViaUi(page, { title, dateTime: daysFromNow(2) });
+    await moveGameToPastViaUi(page, game.id);
+    await resetBunqMock();
+    await enableBunqIntegrationViaUi(page);
+    await page.goto(`/game/${game.id}`);
+    await addParticipantViaUi(page, participant.displayName);
+    await markGameFullyPaidViaBunq(page, game.id, [participant.id]);
+    await page.goto('/');
     await page.getByLabel('Past').check();
     await expect(page.getByText(title)).toHaveCount(0);
     await page.getByLabel('Show fully paid games').check();

--- a/e2e/games-home.spec.ts
+++ b/e2e/games-home.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test } from '@playwright/test';
+import {
+  cleanupE2eData,
+  createAdminAssignment,
+  createDevUserViaApi,
+  createGame,
+  daysFromNow,
+  devLogin,
+  devLoginAs,
+  e2eTitle,
+  nextWeekday,
+  registerUser,
+  updateGame,
+  waitForBackend,
+} from './support/fixtures';
+
+test.describe('games home scenarios', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await cleanupE2eData();
+  });
+
+  test('E2E-HOME-001 participant sees an upcoming game on the games home', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Home Admin', true);
+    const title = e2eTitle(testInfo, 'Home Upcoming');
+    await createGame({ title, createdById: admin.id, dateTime: nextWeekday(0), maxPlayers: 12 });
+
+    await devLogin(page, testInfo, 'Home Participant');
+
+    await expect(page.getByText(title)).toBeVisible();
+  });
+
+  test('E2E-HOME-002 participant opens a game card and reaches details', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Card Admin', true);
+    const title = e2eTitle(testInfo, 'Open Card');
+    await createGame({ title, createdById: admin.id, dateTime: nextWeekday(0) });
+
+    await devLogin(page, testInfo, 'Card Participant');
+    await page.getByText(title).click();
+
+    await expect(page).toHaveURL(/\/game\/\d+/);
+    await expect(page.getByText(title)).toBeVisible();
+  });
+
+  test('E2E-HOME-003 category multi-select shows selected category information', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Category Admin', true);
+    await createGame({
+      title: e2eTitle(testInfo, 'Thursday Five One'),
+      createdById: admin.id,
+      dateTime: nextWeekday(4),
+      withPositions: true,
+    });
+
+    await devLogin(page, testInfo, 'Category Participant');
+    await page.locator('.category-multiselect-trigger').click();
+    await page.getByText('Thursday 5-1').click();
+
+    await expect(page.getByText('Thursday 5-1: Competitive games with assigned positions')).toBeVisible();
+  });
+
+  test('E2E-HOME-004 registered participant sees You are in badge', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Registered Admin', true);
+    const participant = await devLogin(page, testInfo, 'Registered Participant');
+    const title = e2eTitle(testInfo, 'Registered Badge');
+    const game = await createGame({ title, createdById: admin.id, dateTime: nextWeekday(0) });
+    await registerUser(game.id, participant.id, new Date());
+
+    await page.goto('/');
+
+    await expect(page.getByText(title)).toBeVisible();
+    await expect(page.getByText("You're in")).toBeVisible();
+  });
+
+  test('E2E-HOME-005 waitlisted participant sees Waitlist badge', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Waitlist Admin', true);
+    const firstPlayer = await createDevUserViaApi(request, testInfo, 'First Player');
+    const participant = await devLogin(page, testInfo, 'Waitlist Participant');
+    const title = e2eTitle(testInfo, 'Waitlist Badge');
+    const game = await createGame({ title, createdById: admin.id, dateTime: nextWeekday(0), maxPlayers: 1 });
+    await registerUser(game.id, firstPlayer.id, new Date(Date.now() - 60_000));
+    await registerUser(game.id, participant.id, new Date());
+
+    await page.goto('/');
+
+    await expect(page.getByText(title)).toBeVisible();
+    await expect(page.getByText('Waitlist')).toBeVisible();
+  });
+
+  test('E2E-HOME-006 location link opens externally without changing app route', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Location Admin', true);
+    const title = e2eTitle(testInfo, 'Location Card');
+    await createGame({
+      title,
+      createdById: admin.id,
+      dateTime: nextWeekday(0),
+      locationName: 'E2E Maps Gym',
+      locationLink: 'https://maps.example/e2e-gym',
+    });
+
+    await devLogin(page, testInfo, 'Location Participant');
+    const popupPromise = page.waitForEvent('popup');
+    await page.getByRole('link', { name: /E2E Maps Gym/ }).click();
+    const popup = await popupPromise;
+
+    await expect(page).toHaveURL('/');
+    await expect(popup).toHaveURL(/maps\.example\/e2e-gym/);
+    await popup.close();
+  });
+
+  test('E2E-HOME-007 global admin switches between Upcoming and Past filters', async ({ page, request }, testInfo) => {
+    const title = e2eTitle(testInfo, 'Past Filter');
+    const adminUser = await createDevUserViaApi(request, testInfo, 'Past Filter Admin', true);
+    await createGame({ title, createdById: adminUser.id, dateTime: daysFromNow(-1) });
+
+    await devLoginAs(page, adminUser);
+    await page.getByLabel('Past').check();
+
+    await expect(page.getByText(title)).toBeVisible();
+    await page.getByLabel('Upcoming').check();
+    await expect(page.getByText(title)).toHaveCount(0);
+  });
+
+  test('E2E-HOME-008 global admin toggles Show all scheduled games', async ({ page, request }, testInfo) => {
+    const adminUser = await createDevUserViaApi(request, testInfo, 'Show All Admin', true);
+    const title = e2eTitle(testInfo, 'Far Future');
+    await createGame({ title, createdById: adminUser.id, dateTime: nextWeekday(0, 21) });
+
+    await devLoginAs(page, adminUser);
+    await expect(page.getByText(title)).toHaveCount(0);
+    await page.getByLabel('Show all scheduled games').check();
+
+    await expect(page.getByText(title)).toBeVisible();
+  });
+
+  test('E2E-HOME-009 global admin toggles Show fully paid games', async ({ page, request }, testInfo) => {
+    const adminUser = await createDevUserViaApi(request, testInfo, 'Fully Paid Admin', true);
+    const title = e2eTitle(testInfo, 'Fully Paid Past');
+    await createGame({ title, createdById: adminUser.id, dateTime: daysFromNow(-1), fullyPaid: true });
+
+    await devLoginAs(page, adminUser);
+    await page.getByLabel('Past').check();
+    await expect(page.getByText(title)).toHaveCount(0);
+    await page.getByLabel('Show fully paid games').check();
+
+    await expect(page.getByText(title)).toBeVisible();
+  });
+
+  test('E2E-HOME-010 global admin sees non-integration admin controls', async ({ page }, testInfo) => {
+    await devLogin(page, testInfo, 'Toolbar Admin', true);
+
+    await expect(page.getByTitle('Game Administrators')).toBeVisible();
+    await expect(page.getByTitle('Create New Game')).toBeVisible();
+  });
+
+  test('E2E-HOME-011 assigned admin sees create access without global admin links', async ({ page, request }, testInfo) => {
+    const assignedAdmin = await createDevUserViaApi(request, testInfo, 'Assigned Home Admin');
+    await createAdminAssignment(6, false, assignedAdmin.id);
+
+    await devLoginAs(page, assignedAdmin);
+
+    await expect(page.getByTitle('Create New Game')).toBeVisible();
+    await expect(page.getByTitle('Game Administrators')).toHaveCount(0);
+  });
+
+  test('E2E-HOME-012 home error state retries after games API failure', async ({ page }, testInfo) => {
+    let failedOnce = false;
+    await page.route('**/api/games?**', async (route) => {
+      if (!failedOnce) {
+        failedOnce = true;
+        await route.fulfill({ status: 500, body: JSON.stringify({ error: 'E2E forced failure' }) });
+        return;
+      }
+      await route.continue();
+    });
+
+    await devLogin(page, testInfo, 'Retry Participant');
+
+    await expect(page.getByRole('heading', { name: 'Error' })).toBeVisible();
+    await page.getByRole('button', { name: 'Retry' }).click();
+    await expect(page.getByRole('heading', { name: 'Error' })).toHaveCount(0);
+  });
+});

--- a/e2e/games-home.spec.ts
+++ b/e2e/games-home.spec.ts
@@ -200,4 +200,43 @@ test.describe('games home scenarios', () => {
     await page.getByRole('button', { name: 'Retry' }).click();
     await expect(page.getByRole('heading', { name: 'Error' })).toHaveCount(0);
   });
+
+  test('E2E-HOME-013 default Sunday filter shows empty when only Thursday 5-1 games exist', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Sunday Filter Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Sunday Filter Participant');
+    await devLoginAs(page, admin);
+    await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Thursday Five One Only'),
+      dateTime: nextWeekday(4),
+      withPositions: true,
+    });
+
+    await switchToUser(page, participant);
+    await page.goto('/');
+    await page.evaluate(() => localStorage.removeItem('selectedCategories'));
+    await page.reload();
+
+    await expect(page.getByText('No games available')).toBeVisible();
+  });
+
+  test('E2E-HOME-014 category multiselect can exclude all visible games', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Cat Exclude Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Cat Exclude Participant');
+    await devLoginAs(page, admin);
+    await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Sunday Category Game'),
+      dateTime: nextWeekday(0),
+      withPositions: false,
+    });
+
+    await switchToUser(page, participant);
+    await page.goto('/');
+    await page.evaluate(() => localStorage.removeItem('selectedCategories'));
+    await page.reload();
+    await page.locator('.category-multiselect-trigger').click();
+    await page.locator('label.category-multiselect-option').filter({ hasText: 'Thursday 5-1' }).click();
+    await page.locator('label.category-multiselect-option').filter({ hasText: 'Sunday' }).click();
+
+    await expect(page.getByText('No games available')).toBeVisible();
+  });
 });

--- a/e2e/registration-windows-guests-blocked.spec.ts
+++ b/e2e/registration-windows-guests-blocked.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from '@playwright/test';
+import {
+  cleanupE2eData,
+  createDevUserViaApi,
+  createGameViaUi,
+  daysFromNow,
+  devLoginAs,
+  e2eTitle,
+  nextWeekday,
+  setUserBlockReason,
+  switchToUser,
+  waitForBackend,
+} from './support/fixtures';
+
+test.describe('registration windows, guests, and blocked users', () => {
+  test.beforeEach(async ({ request }) => {
+    await waitForBackend(request);
+    await cleanupE2eData();
+  });
+
+  test('E2E-WIN-001 participant sees registration opens message and cannot join yet', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Win1 Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Win1 Participant');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Far Registration'),
+      dateTime: daysFromNow(14),
+    });
+
+    await switchToUser(page, participant);
+    await page.goto(`/game/${game.id}`);
+
+    await expect(page.getByRole('button', { name: 'Join Game' })).toHaveCount(0);
+    await expect(page.getByText(/Registration opens/)).toBeVisible();
+    await expect(page.getByText(/10 days before the game/)).toBeVisible();
+  });
+
+  test('E2E-WIN-002 participant can join but add guest is hidden before guest window', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Win2 Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Win2 Participant');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Guest Window'),
+      dateTime: daysFromNow(6),
+    });
+
+    await switchToUser(page, participant);
+    await page.goto(`/game/${game.id}`);
+
+    await expect(page.getByRole('button', { name: 'Join Game' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add guest' })).toHaveCount(0);
+  });
+
+  test('E2E-BLOCK-001 blocked user cannot join and cannot add a guest', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Block Admin', true);
+    const blocked = await createDevUserViaApi(request, testInfo, 'Blocked User');
+    await setUserBlockReason(blocked.id, 'E2E unpaid games policy');
+
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Block Join'),
+      dateTime: daysFromNow(2),
+    });
+
+    await switchToUser(page, blocked);
+    await page.goto(`/game/${game.id}`);
+
+    await page.getByRole('button', { name: 'Join Game' }).click();
+    await expect(page.locator('.dialog-overlay .dialog-title').filter({ hasText: 'Registration blocked' })).toBeVisible();
+    await expect(page.locator('.dialog-overlay .dialog-message')).toContainText('E2E unpaid games policy');
+    await page.locator('.dialog-overlay').getByRole('button', { name: 'OK' }).click();
+
+    await page.getByRole('button', { name: 'Add guest' }).click();
+    await expect(page.locator('.dialog-overlay .dialog-title').filter({ hasText: 'Guest registration blocked' })).toBeVisible();
+    await expect(page.locator('.dialog-overlay .dialog-message')).toContainText('E2E unpaid games policy');
+    await page.locator('.dialog-overlay').getByRole('button', { name: 'OK' }).click();
+  });
+
+  test('E2E-GUEST-001 participant unregisters a guest from the players list', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Guest Unreg Admin', true);
+    const participant = await createDevUserViaApi(request, testInfo, 'Guest Unreg Participant');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Guest Unreg'),
+      dateTime: daysFromNow(2),
+    });
+
+    await switchToUser(page, participant);
+    await page.goto(`/game/${game.id}`);
+    await page.getByRole('button', { name: 'Join Game' }).click();
+    await expect(page.getByRole('heading', { name: 'Will you bring a volleyball?' })).toBeVisible();
+    await page.getByRole('button', { name: /No, I won't bring one/ }).click();
+    await expect(page.getByText("You're in", { exact: true })).toBeVisible();
+
+    const guestName = `GuestUnreg${Date.now().toString(36)}`;
+    await page.getByRole('button', { name: 'Add guest' }).click();
+    await page.getByLabel('Guest Name:').fill(guestName);
+    await page.getByRole('button', { name: 'Register Guest' }).click();
+    await expect(page.getByText(guestName)).toBeVisible();
+
+    await page.getByRole('button', { name: `Unregister guest ${guestName}` }).click();
+    await expect(page.locator('.dialog-overlay .dialog-title').filter({ hasText: 'Unregister Guest' })).toBeVisible();
+    await page.locator('.dialog-overlay').getByRole('button', { name: 'Unregister Guest' }).click();
+
+    await expect(page.getByText(guestName)).toHaveCount(0);
+  });
+
+  test('E2E-GUEST-002 global admin adds guest on readonly game with inviter selection', async ({ page, request }, testInfo) => {
+    const admin = await createDevUserViaApi(request, testInfo, 'Inviter Admin', true);
+    const inviter = await createDevUserViaApi(request, testInfo, 'Inviter User');
+    await devLoginAs(page, admin);
+    const game = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Readonly Guest Inviter'),
+      dateTime: daysFromNow(5),
+      readonly: true,
+    });
+
+    await page.goto(`/game/${game.id}`);
+    await page.getByRole('button', { name: 'Add guest' }).click();
+    await expect(page.getByRole('heading', { name: 'Register guest' })).toBeVisible();
+    await expect(page.getByText('Invited by:')).toBeVisible();
+
+    await page.getByPlaceholder('Search user (inviter)...').fill(inviter.displayName);
+    await page.getByText(inviter.displayName, { exact: true }).click();
+
+    const guestName = `InvitedGuest${Date.now().toString(36)}`;
+    await page.getByLabel('Guest Name:').fill(guestName);
+    await page.getByRole('button', { name: 'Register Guest' }).click();
+
+    await expect(page.getByText(guestName)).toBeVisible();
+    await expect(page.getByText(new RegExp(`Invited by ${inviter.displayName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`))).toBeVisible();
+  });
+});

--- a/e2e/registration-windows-guests-blocked.spec.ts
+++ b/e2e/registration-windows-guests-blocked.spec.ts
@@ -6,8 +6,6 @@ import {
   daysFromNow,
   devLoginAs,
   e2eTitle,
-  nextWeekday,
-  setUserBlockReason,
   switchToUser,
   waitForBackend,
 } from './support/fixtures';
@@ -54,16 +52,39 @@ test.describe('registration windows, guests, and blocked users', () => {
   test('E2E-BLOCK-001 blocked user cannot join and cannot add a guest', async ({ page, request }, testInfo) => {
     const admin = await createDevUserViaApi(request, testInfo, 'Block Admin', true);
     const blocked = await createDevUserViaApi(request, testInfo, 'Blocked User');
-    await setUserBlockReason(blocked.id, 'E2E unpaid games policy');
-
     await devLoginAs(page, admin);
-    const game = await createGameViaUi(page, {
+
+    const joinableGame = await createGameViaUi(page, {
       title: e2eTitle(testInfo, 'Block Join'),
       dateTime: daysFromNow(2),
     });
 
+    const readonlyGame = await createGameViaUi(page, {
+      title: e2eTitle(testInfo, 'Block Setup Readonly'),
+      dateTime: daysFromNow(5),
+      readonly: true,
+    });
+
+    await page.goto(`/game/${readonlyGame.id}`);
+    await page.locator('.admin-actions').getByRole('button', { name: 'Add Participant' }).click();
+    await page.getByPlaceholder('Search users to add...').fill(blocked.displayName);
+    await page.getByText(blocked.displayName, { exact: true }).click();
+    await expect(page.getByText(blocked.displayName)).toBeVisible();
+
+    await page.locator('.player-item').filter({ hasText: blocked.displayName }).locator('.player-details').click();
+    await expect(page.getByRole('heading', { name: 'Player details' })).toBeVisible();
+
+    page.once('dialog', async (dialog) => {
+      expect(dialog.type()).toBe('prompt');
+      await dialog.accept('E2E unpaid games policy');
+    });
+    await page.locator('.player-info-dialog').getByRole('button', { name: 'Block' }).click();
+
+    await expect(page.locator('.player-info-dialog').getByText('Blocked: E2E unpaid games policy')).toBeVisible();
+    await page.locator('.player-info-dialog').getByRole('button', { name: 'Close' }).click();
+
     await switchToUser(page, blocked);
-    await page.goto(`/game/${game.id}`);
+    await page.goto(`/game/${joinableGame.id}`);
 
     await page.getByRole('button', { name: 'Join Game' }).click();
     await expect(page.locator('.dialog-overlay .dialog-title').filter({ hasText: 'Registration blocked' })).toBeVisible();

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -418,15 +418,56 @@ export async function moveGameToPastViaUi(page: Page, gameId: number, pastDate =
   await expect(page).toHaveURL(new RegExp(`/game/${gameId}$`));
 }
 
-export async function sendPaymentRequestsViaUi(page: Page): Promise<void> {
+export async function addParticipantViaUi(page: Page, displayName: string) {
+  await page.locator('.admin-actions').getByRole('button', { name: 'Add Participant' }).click();
+  await page.getByPlaceholder('Search users to add...').fill(displayName);
+  await page.getByText(displayName, { exact: true }).click();
+  await expect(page.locator('.player-item').filter({ hasText: displayName })).toBeVisible();
+}
+
+export async function enableBunqIntegrationForUserViaUi(page: Page, userId: number): Promise<void> {
+  await page.goto(`/bunq-settings/user/${userId}`);
+  await waitForBunqSettingsReady(page);
+
+  if (await page.getByText(/Bunq integration is enabled/).isVisible().catch(() => false)) {
+    return;
+  }
+
+  await openBunqCredentialsForm(page);
+  await fillBunqCredentialsForm(page, {
+    apiKey: BUNQ_E2E_API_KEY,
+    apiKeyName: BUNQ_E2E_API_KEY_NAME,
+    password: BUNQ_E2E_PASSWORD,
+  });
+  await submitBunqCredentialsForm(page);
+  await expect(page.getByText(/Bunq integration enabled successfully/i)).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByText(/Bunq integration is enabled/)).toBeVisible();
+}
+
+export async function submitSendPaymentRequestsPassword(page: Page, password: string) {
   const sendBtn = page.getByTitle('Send payment requests to unpaid players');
   await expect(sendBtn).toBeVisible({ timeout: 30_000 });
   await sendBtn.click();
-  await page.locator('.password-dialog-overlay').getByLabel('Password:').fill(BUNQ_E2E_PASSWORD);
+  await expect(page.locator('.password-dialog-overlay').getByLabel('Password:')).toBeVisible();
+  await page.locator('.password-dialog-overlay').getByLabel('Password:').fill(password);
   await page.locator('.password-dialog-overlay').getByRole('button', { name: 'Submit' }).click();
+}
+
+export async function dismissPaymentRequestsSentDialog(page: Page, expectedCount?: number) {
   const paymentSentDialog = page.getByRole('dialog').filter({ hasText: 'Payment requests sent' });
-  await expect(paymentSentDialog.getByText(/payment requests sent successfully/i)).toBeVisible({ timeout: 60_000 });
+  if (expectedCount !== undefined) {
+    await expect(
+      paymentSentDialog.getByText(new RegExp(`${expectedCount} payment requests sent successfully`))
+    ).toBeVisible({ timeout: 60_000 });
+  } else {
+    await expect(paymentSentDialog.getByText(/payment requests sent successfully/i)).toBeVisible({ timeout: 60_000 });
+  }
   await paymentSentDialog.getByRole('button', { name: 'OK' }).click();
+}
+
+export async function sendPaymentRequestsViaUi(page: Page, password = BUNQ_E2E_PASSWORD): Promise<void> {
+  await submitSendPaymentRequestsPassword(page, password);
+  await dismissPaymentRequestsSentDialog(page);
   await expect(page.getByText('Payments collected by')).toBeVisible({ timeout: 30_000 });
 }
 

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -228,8 +228,27 @@ export async function registerForGameViaUi(page: Page, user: DevUser, gameId: nu
   await expect(page.getByText(expectedStatus, { exact: true })).toBeVisible();
 }
 
-export async function updateGame(id: number, updates: Record<string, unknown>) {
-  const entries = Object.entries(updates);
+/** Fields that cannot be set through the mini-app UI (allowed for E2E DB helpers only). */
+export type GameDbOnlyPatch = {
+  tag?: string | null;
+  fully_paid?: boolean;
+};
+
+export async function updateGame(id: number, updates: GameDbOnlyPatch): Promise<void> {
+  const allowedKeys = new Set(['tag', 'fully_paid']);
+  const keys = Object.keys(updates);
+  const bad = keys.filter((k) => !allowedKeys.has(k));
+  if (bad.length > 0) {
+    throw new Error(`updateGame: disallowed keys: ${bad.join(', ')}. Only "tag" and "fully_paid" are permitted.`);
+  }
+
+  const entries: [string, unknown][] = [];
+  if (Object.prototype.hasOwnProperty.call(updates, 'tag')) {
+    entries.push(['tag', updates.tag ?? null]);
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'fully_paid')) {
+    entries.push(['fully_paid', updates.fully_paid]);
+  }
   if (entries.length === 0) return;
 
   const setSql = entries.map(([key], index) => `${key} = $${index + 2}`).join(', ');

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -27,23 +27,6 @@ type UiGameInput = {
   locationLink?: string;
 };
 
-type GameInput = {
-  title: string;
-  createdById: number;
-  dateTime?: Date;
-  maxPlayers?: number;
-  unregisterDeadlineHours?: number;
-  paymentAmount?: number;
-  pricingMode?: 'per_participant' | 'total_cost';
-  fullyPaid?: boolean;
-  withPositions?: boolean;
-  withPriorityPlayers?: boolean;
-  readonly?: boolean;
-  locationName?: string;
-  locationLink?: string;
-  tag?: 'halloween' | 'newyear' | 'march8';
-};
-
 const pool = new Pool({
   host: process.env.POSTGRES_HOST || '127.0.0.1',
   port: Number(process.env.POSTGRES_PORT || 5432),
@@ -243,51 +226,6 @@ export async function registerForGameViaUi(page: Page, user: DevUser, gameId: nu
   await expect(page.getByRole('heading', { name: 'Will you bring a volleyball?' })).toBeVisible();
   await page.getByRole('button', { name: /No, I won't bring one/ }).click();
   await expect(page.getByText(expectedStatus, { exact: true })).toBeVisible();
-}
-
-export async function createGame(input: GameInput): Promise<GameFixture> {
-  const dateTime = input.dateTime || daysFromNow(2);
-  const result = await pool.query(
-    `insert into games (
-      date_time,
-      max_players,
-      unregister_deadline_hours,
-      payment_amount,
-      pricing_mode,
-      fully_paid,
-      with_positions,
-      with_priority_players,
-      readonly,
-      location_name,
-      location_link,
-      tag,
-      title,
-      created_by_id
-    ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
-    returning id, title, date_time as "dateTime"`,
-    [
-      dateTime,
-      input.maxPlayers ?? 14,
-      input.unregisterDeadlineHours ?? 5,
-      input.paymentAmount ?? 500,
-      input.pricingMode ?? 'per_participant',
-      input.fullyPaid ?? false,
-      input.withPositions ?? false,
-      input.withPriorityPlayers ?? false,
-      input.readonly ?? false,
-      input.locationName ?? 'E2E Sports Hall',
-      input.locationLink ?? 'https://maps.example/e2e',
-      input.tag ?? null,
-      input.title,
-      input.createdById,
-    ]
-  );
-
-  return {
-    id: result.rows[0].id,
-    title: result.rows[0].title,
-    dateTime: new Date(result.rows[0].dateTime),
-  };
 }
 
 export async function updateGame(id: number, updates: Record<string, unknown>) {

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -274,6 +274,7 @@ export async function cleanupE2eData() {
   await pool.query(`delete from game_registrations where game_id in (select id from games where title like 'E2E %')`);
   await pool.query(`delete from priority_players where user_id in (select id from users where display_name like 'E2E %')`);
   await pool.query(`delete from game_administrators where user_id in (select id from users where display_name like 'E2E %')`);
+  await pool.query(`delete from bunq_credentials where user_id in (select id from users where display_name like 'E2E %')`);
   await pool.query(`delete from games where title like 'E2E %'`);
   await pool.query(`delete from users where display_name like 'E2E %'`);
 }
@@ -328,22 +329,77 @@ export const BUNQ_E2E_PASSWORD = 'BunqE2E!Pass9';
 export const BUNQ_E2E_API_KEY = 'e2e-bunq-api-key';
 export const BUNQ_E2E_API_KEY_NAME = 'E2E Bunq Client';
 
+export async function waitForBunqSettingsReady(page: Page, heading?: string | RegExp) {
+  await expect(page.getByRole('heading', { name: heading ?? 'Bunq Settings' })).toBeVisible();
+  await expect(page.getByText('Loading...')).toHaveCount(0, { timeout: 30_000 });
+}
+
+export async function openBunqSettingsFromGamesHome(page: Page) {
+  await page.goto('/');
+  await page.getByTitle('Bunq Settings').click();
+  await waitForBunqSettingsReady(page);
+}
+
+export async function openBunqCredentialsForm(page: Page) {
+  await page.getByRole('button', { name: 'Enable Bunq Integration' }).click();
+  await expect(page.getByRole('heading', { name: 'Specify Bunq API Credentials' })).toBeVisible();
+}
+
+export async function fillBunqCredentialsForm(
+  page: Page,
+  credentials: { apiKey: string; apiKeyName: string; password: string }
+) {
+  await page.locator('#apiKey').fill(credentials.apiKey);
+  await page.locator('#apiKeyName').fill(credentials.apiKeyName);
+  await page.locator('.credentials-form #password').fill(credentials.password);
+}
+
+export async function submitBunqCredentialsForm(page: Page) {
+  await page.getByRole('button', { name: 'Enable Integration' }).click();
+}
+
 export async function enableBunqIntegrationViaUi(page: Page): Promise<void> {
   await page.goto('/bunq-settings');
-  await expect(page.getByRole('heading', { name: 'Bunq Settings' })).toBeVisible();
-  await expect(page.getByText('Loading...')).toHaveCount(0, { timeout: 30_000 });
+  await waitForBunqSettingsReady(page);
 
   if (await page.getByText(/Bunq integration is enabled/).isVisible().catch(() => false)) {
     return;
   }
 
-  await page.getByRole('button', { name: 'Enable Bunq Integration' }).click();
-  await page.locator('#apiKey').fill(BUNQ_E2E_API_KEY);
-  await page.locator('#apiKeyName').fill(BUNQ_E2E_API_KEY_NAME);
-  await page.locator('.credentials-form #password').fill(BUNQ_E2E_PASSWORD);
-  await page.getByRole('button', { name: 'Enable Integration' }).click();
+  await openBunqCredentialsForm(page);
+  await fillBunqCredentialsForm(page, {
+    apiKey: BUNQ_E2E_API_KEY,
+    apiKeyName: BUNQ_E2E_API_KEY_NAME,
+    password: BUNQ_E2E_PASSWORD,
+  });
+  await submitBunqCredentialsForm(page);
   await expect(page.getByText(/Bunq integration enabled successfully/i)).toBeVisible({ timeout: 60_000 });
   await expect(page.getByText(/Bunq integration is enabled/)).toBeVisible();
+}
+
+export async function disableBunqIntegrationViaUi(page: Page, confirm = true) {
+  page.once('dialog', async (dialog) => {
+    expect(dialog.type()).toBe('confirm');
+    if (confirm) {
+      await dialog.accept();
+    } else {
+      await dialog.dismiss();
+    }
+  });
+  await page.getByRole('button', { name: 'Disable Integration' }).click();
+}
+
+export async function loadMonetaryAccountsViaUi(page: Page, password = BUNQ_E2E_PASSWORD) {
+  await page.getByRole('button', { name: 'Choose account to receive payments to' }).click();
+  await page.locator('#accountPassword').fill(password);
+  await page.getByRole('button', { name: 'Load Accounts' }).click();
+}
+
+export async function installBunqWebhookViaUi(page: Page, password: string) {
+  await page.getByRole('button', { name: 'Install Webhook' }).click();
+  await expect(page.locator('.password-dialog-overlay').getByRole('heading', { name: 'Install Bunq Webhook' })).toBeVisible();
+  await page.locator('.password-dialog-overlay').getByLabel('Password:').fill(password);
+  await page.locator('.password-dialog-overlay').getByRole('button', { name: 'Submit' }).click();
 }
 
 export async function moveGameToPastViaUi(page: Page, gameId: number, pastDate = daysFromNow(-2)): Promise<void> {

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -1,0 +1,242 @@
+import { expect, type APIRequestContext, type Page, type TestInfo } from '@playwright/test';
+import { Pool } from 'pg';
+
+export type DevUser = {
+  id: number;
+  displayName: string;
+  phoneLocal: string;
+  isAdmin: boolean;
+};
+
+export type GameFixture = {
+  id: number;
+  title: string;
+  dateTime: Date;
+};
+
+type GameInput = {
+  title: string;
+  createdById: number;
+  dateTime?: Date;
+  maxPlayers?: number;
+  unregisterDeadlineHours?: number;
+  paymentAmount?: number;
+  pricingMode?: 'per_participant' | 'total_cost';
+  fullyPaid?: boolean;
+  withPositions?: boolean;
+  withPriorityPlayers?: boolean;
+  readonly?: boolean;
+  locationName?: string;
+  locationLink?: string;
+  tag?: 'halloween' | 'newyear' | 'march8';
+};
+
+const pool = new Pool({
+  host: process.env.POSTGRES_HOST || '127.0.0.1',
+  port: Number(process.env.POSTGRES_PORT || 5432),
+  user: process.env.POSTGRES_USER || 'postgres',
+  password: process.env.POSTGRES_PASSWORD || 'postgres',
+  database: process.env.POSTGRES_DB || 'volley_game_central',
+});
+
+export async function waitForBackend(request: APIRequestContext) {
+  await expect
+    .poll(
+      async () => {
+        try {
+          const response = await request.get('/api/health', { timeout: 5_000 });
+          return response.status();
+        } catch {
+          return 0;
+        }
+      },
+      { timeout: 45_000, message: 'backend health endpoint should be reachable through Vite proxy' }
+    )
+    .toBe(200);
+}
+
+export function uniqueRunId(testInfo: TestInfo) {
+  return `${testInfo.workerIndex}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+export function uniqueName(testInfo: TestInfo, label: string) {
+  return `E2E ${label} ${uniqueRunId(testInfo)}`;
+}
+
+export function uniquePhoneLocal(testInfo: TestInfo, suffix: number) {
+  const timestamp = Date.now().toString().slice(-8);
+  return `6${timestamp}${testInfo.workerIndex}${suffix}`;
+}
+
+export async function openDevLogin(page: Page) {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+  await page.getByRole('button', { name: 'Phone number' }).click();
+  await expect(page.getByText('Dev mode: No SMS verification required')).toBeVisible();
+}
+
+export async function devLogin(page: Page, testInfo: TestInfo, label: string, isAdmin = false): Promise<DevUser> {
+  const displayName = uniqueName(testInfo, label);
+  const phoneLocal = uniquePhoneLocal(testInfo, isAdmin ? 8 : 1);
+
+  return devLoginAs(page, { id: 0, displayName, phoneLocal, isAdmin });
+}
+
+export async function devLoginAs(page: Page, user: DevUser): Promise<DevUser> {
+  await openDevLogin(page);
+  await page.getByLabel('Phone number').fill(user.phoneLocal);
+  await page.getByLabel('Display name').fill(user.displayName);
+
+  if (user.isAdmin) {
+    await page.getByLabel('Administrator').check();
+  }
+
+  await page.getByRole('button', { name: 'Dev Login' }).click();
+  await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible();
+  await expect(page.getByLabel('Edit display name')).toContainText(user.displayName);
+
+  const currentUser = await page.evaluate(async () => {
+    const response = await fetch('/api/users/me', { credentials: 'include' });
+    if (!response.ok) throw new Error(`Failed to load current user: ${response.status}`);
+    return response.json();
+  });
+
+  return {
+    id: currentUser.user.id,
+    displayName: user.displayName,
+    phoneLocal: user.phoneLocal,
+    isAdmin: user.isAdmin,
+  };
+}
+
+export async function createDevUserViaApi(request: APIRequestContext, testInfo: TestInfo, label: string, isAdmin = false): Promise<DevUser> {
+  const displayName = uniqueName(testInfo, label);
+  const phoneLocal = uniquePhoneLocal(testInfo, isAdmin ? 9 : 2);
+  const response = await request.post('/api/auth/dev-login', {
+    data: {
+      phoneNumber: `+31${phoneLocal}`,
+      displayName,
+      isAdmin,
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const body = await response.json();
+  return {
+    id: body.user.id,
+    displayName,
+    phoneLocal,
+    isAdmin,
+  };
+}
+
+export function daysFromNow(days: number, hour = 18) {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  date.setHours(hour, 0, 0, 0);
+  return date;
+}
+
+export function nextWeekday(jsDay: number, minDaysAhead = 1, hour = 18) {
+  const date = new Date();
+  const current = date.getDay();
+  let delta = (jsDay - current + 7) % 7;
+  if (delta < minDaysAhead) delta += 7;
+  date.setDate(date.getDate() + delta);
+  date.setHours(hour, 0, 0, 0);
+  return date;
+}
+
+export function e2eTitle(testInfo: TestInfo, label: string) {
+  return `E2E ${label} ${uniqueRunId(testInfo)}`;
+}
+
+export async function createGame(input: GameInput): Promise<GameFixture> {
+  const dateTime = input.dateTime || daysFromNow(2);
+  const result = await pool.query(
+    `insert into games (
+      date_time,
+      max_players,
+      unregister_deadline_hours,
+      payment_amount,
+      pricing_mode,
+      fully_paid,
+      with_positions,
+      with_priority_players,
+      readonly,
+      location_name,
+      location_link,
+      tag,
+      title,
+      created_by_id
+    ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+    returning id, title, date_time as "dateTime"`,
+    [
+      dateTime,
+      input.maxPlayers ?? 14,
+      input.unregisterDeadlineHours ?? 5,
+      input.paymentAmount ?? 500,
+      input.pricingMode ?? 'per_participant',
+      input.fullyPaid ?? false,
+      input.withPositions ?? false,
+      input.withPriorityPlayers ?? false,
+      input.readonly ?? false,
+      input.locationName ?? 'E2E Sports Hall',
+      input.locationLink ?? 'https://maps.example/e2e',
+      input.tag ?? null,
+      input.title,
+      input.createdById,
+    ]
+  );
+
+  return {
+    id: result.rows[0].id,
+    title: result.rows[0].title,
+    dateTime: new Date(result.rows[0].dateTime),
+  };
+}
+
+export async function findGameByTitle(title: string) {
+  const result = await pool.query(`select * from games where title = $1 order by id desc limit 1`, [title]);
+  return result.rows[0] || null;
+}
+
+export async function updateGame(id: number, updates: Record<string, unknown>) {
+  const entries = Object.entries(updates);
+  if (entries.length === 0) return;
+
+  const setSql = entries.map(([key], index) => `${key} = $${index + 2}`).join(', ');
+  await pool.query(`update games set ${setSql} where id = $1`, [id, ...entries.map(([, value]) => value)]);
+}
+
+export async function registerUser(gameId: number, userId: number, createdAt: Date, guestName?: string, bringingTheBall = false, paid = false) {
+  const result = await pool.query(
+    `insert into game_registrations (game_id, user_id, guest_name, bringing_the_ball, paid, created_at)
+     values ($1,$2,$3,$4,$5,$6)
+     returning id`,
+    [gameId, userId, guestName ?? null, bringingTheBall, paid, createdAt]
+  );
+  return result.rows[0].id as number;
+}
+
+export async function createAdminAssignment(dayOfWeek: number, withPositions: boolean, userId: number) {
+  const result = await pool.query(
+    `insert into game_administrators (day_of_week, with_positions, user_id)
+     values ($1,$2,$3)
+     returning id`,
+    [dayOfWeek, withPositions, userId]
+  );
+  return result.rows[0].id as number;
+}
+
+export async function cleanupE2eData() {
+  await pool.query(`delete from payment_requests where payment_request_id like 'e2e-%'`);
+  await pool.query(`delete from game_registrations where game_id in (select id from games where title like 'E2E %')`);
+  await pool.query(`delete from priority_players where user_id in (select id from users where display_name like 'E2E %')`);
+  await pool.query(`delete from game_administrators where user_id in (select id from users where display_name like 'E2E %')`);
+  await pool.query(`delete from games where title like 'E2E %'`);
+  await pool.query(`delete from users where display_name like 'E2E %'`);
+}
+
+export async function closeDbPool() {
+  await pool.end();
+}

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -228,31 +228,31 @@ export async function registerForGameViaUi(page: Page, user: DevUser, gameId: nu
   await expect(page.getByText(expectedStatus, { exact: true })).toBeVisible();
 }
 
-/** Fields that cannot be set through the mini-app UI (allowed for E2E DB helpers only). */
-export type GameDbOnlyPatch = {
-  tag?: string | null;
-  fully_paid?: boolean;
-};
+/** Game tag cannot be set through the mini-app UI; use for seasonal/special game E2E setup only. */
+export async function updateGameTag(id: number, tag: string | null): Promise<void> {
+  await pool.query(`update games set tag = $2 where id = $1`, [id, tag]);
+}
 
-export async function updateGame(id: number, updates: GameDbOnlyPatch): Promise<void> {
-  const allowedKeys = new Set(['tag', 'fully_paid']);
-  const keys = Object.keys(updates);
-  const bad = keys.filter((k) => !allowedKeys.has(k));
-  if (bad.length > 0) {
-    throw new Error(`updateGame: disallowed keys: ${bad.join(', ')}. Only "tag" and "fully_paid" are permitted.`);
+/**
+ * Mark a past game fully paid via admin payment requests and Bunq mock webhooks.
+ * Requires Bunq integration enabled, unpaid registered participants, and admin on `page`.
+ */
+export async function markGameFullyPaidViaBunq(
+  page: Page,
+  gameId: number,
+  participantUserIds: number[]
+): Promise<void> {
+  await page.goto(`/game/${gameId}`);
+  await sendPaymentRequestsViaUi(page);
+  for (const userId of participantUserIds) {
+    const inquiryId = await getPaymentRequestIdForUserRegistration(gameId, userId);
+    if (!inquiryId) {
+      throw new Error(`markGameFullyPaidViaBunq: no payment request for game ${gameId} user ${userId}`);
+    }
+    await deliverBunqRequestInquiryAcceptedWebhook(inquiryId);
   }
-
-  const entries: [string, unknown][] = [];
-  if (Object.prototype.hasOwnProperty.call(updates, 'tag')) {
-    entries.push(['tag', updates.tag ?? null]);
-  }
-  if (Object.prototype.hasOwnProperty.call(updates, 'fully_paid')) {
-    entries.push(['fully_paid', updates.fully_paid]);
-  }
-  if (entries.length === 0) return;
-
-  const setSql = entries.map(([key], index) => `${key} = $${index + 2}`).join(', ');
-  await pool.query(`update games set ${setSql} where id = $1`, [id, ...entries.map(([, value]) => value)]);
+  await page.reload();
+  await expect(page.getByText('Payments collected by')).toBeVisible({ timeout: 30_000 });
 }
 
 export async function countRegistrations(gameId: number) {

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -14,6 +14,19 @@ export type GameFixture = {
   dateTime: Date;
 };
 
+type UiGameInput = {
+  title: string;
+  dateTime?: Date;
+  maxPlayers?: number;
+  unregisterDeadlineHours?: number;
+  paymentAmount?: string;
+  pricingMode?: 'per_participant' | 'total_cost';
+  withPositions?: boolean;
+  readonly?: boolean;
+  locationName?: string;
+  locationLink?: string;
+};
+
 type GameInput = {
   title: string;
   createdById: number;
@@ -148,6 +161,75 @@ export function nextWeekday(jsDay: number, minDaysAhead = 1, hour = 18) {
 
 export function e2eTitle(testInfo: TestInfo, label: string) {
   return `E2E ${label} ${uniqueRunId(testInfo)}`;
+}
+
+function formatDateForInput(date: Date) {
+  const month = date.toLocaleString('en-US', { month: 'long' });
+  const day = date.getDate();
+  const year = date.getFullYear();
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  return `${month} ${day}, ${year} ${hours}:${minutes}`;
+}
+
+export async function setCheckbox(page: Page, selector: string, checked = true) {
+  const input = page.locator(selector);
+  if ((await input.isChecked()) !== checked) {
+    await page.locator(`label[for="${selector.replace('#', '')}"]`).click();
+  }
+}
+
+export async function createGameViaUi(page: Page, input: UiGameInput): Promise<GameFixture> {
+  await page.goto('/games/new');
+  await expect(page.getByRole('heading', { name: 'Create New Game' })).toBeVisible();
+
+  const dateTime = input.dateTime || daysFromNow(2);
+  const dateInput = page.getByPlaceholder('Select date and time');
+  await dateInput.fill(formatDateForInput(dateTime));
+  await dateInput.press('Enter');
+  await page.locator('#maxPlayers').fill(String(input.maxPlayers ?? 14));
+  await page.locator('#unregisterDeadlineHours').fill(String(input.unregisterDeadlineHours ?? 5));
+  await page.locator('#paymentAmount').fill(input.paymentAmount ?? '5.00');
+  await page.locator('#locationName').fill(input.locationName ?? 'E2E Sports Hall');
+  await page.locator('#locationLink').fill(input.locationLink ?? 'https://maps.example/e2e');
+  await page.locator('#title').fill(input.title);
+
+  if (input.pricingMode === 'total_cost') {
+    await setCheckbox(page, '#pricingMode');
+  }
+  if (input.withPositions) {
+    await setCheckbox(page, '#withPositions');
+  }
+  if (input.readonly) {
+    await setCheckbox(page, '#readonly');
+  }
+
+  await page.getByRole('button', { name: 'Create Game' }).click();
+  await expect(page).toHaveURL('/');
+
+  const created = await findGameByTitle(input.title);
+  expect(created).toBeTruthy();
+  return {
+    id: created.id,
+    title: created.title,
+    dateTime: new Date(created.date_time),
+  };
+}
+
+export async function switchToUser(page: Page, user: DevUser) {
+  if (await page.getByRole('button', { name: 'Logout' }).isVisible().catch(() => false)) {
+    await page.getByRole('button', { name: 'Logout' }).click();
+  }
+  return devLoginAs(page, user);
+}
+
+export async function registerForGameViaUi(page: Page, user: DevUser, gameId: number, expectedStatus = "You're in") {
+  await switchToUser(page, user);
+  await page.goto(`/game/${gameId}`);
+  await page.getByRole('button', { name: 'Join Game' }).click();
+  await expect(page.getByRole('heading', { name: 'Will you bring a volleyball?' })).toBeVisible();
+  await page.getByRole('button', { name: /No, I won't bring one/ }).click();
+  await expect(page.getByText(expectedStatus, { exact: true })).toBeVisible();
 }
 
 export async function createGame(input: GameInput): Promise<GameFixture> {

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -259,6 +259,65 @@ export async function cleanupE2eData() {
   await pool.query(`delete from users where display_name like 'E2E %'`);
 }
 
+const BUNQ_MOCK_CONTROL_ORIGIN = process.env.BUNQ_MOCK_CONTROL_ORIGIN ?? 'http://127.0.0.1:3999';
+const BUNQ_MOCK_CONTROL_TOKEN = process.env.BUNQ_MOCK_CONTROL_TOKEN ?? 'e2e-bunq-mock-secret';
+
+export async function resetBunqMock(): Promise<void> {
+  const res = await fetch(`${BUNQ_MOCK_CONTROL_ORIGIN}/reset`, {
+    method: 'POST',
+    headers: { 'X-Bunq-Mock-Control-Token': BUNQ_MOCK_CONTROL_TOKEN },
+  });
+  if (!res.ok) {
+    throw new Error(`resetBunqMock failed: HTTP ${res.status} ${await res.text()}`);
+  }
+}
+
+export async function deliverBunqRequestInquiryAcceptedWebhook(
+  requestInquiryId: string,
+  targetUrlOverride?: string
+): Promise<void> {
+  const res = await fetch(`${BUNQ_MOCK_CONTROL_ORIGIN}/webhooks/deliver-request-inquiry-accepted`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Bunq-Mock-Control-Token': BUNQ_MOCK_CONTROL_TOKEN,
+    },
+    body: JSON.stringify({
+      requestInquiryId,
+      ...(targetUrlOverride ? { targetUrlOverride } : {}),
+    }),
+  });
+  const body = (await res.json().catch(() => ({}))) as {
+    ok?: boolean;
+    error?: string;
+    status?: number;
+    responseSnippet?: string;
+    detail?: string;
+  };
+  if (!res.ok) {
+    throw new Error(`deliverBunqRequestInquiryAcceptedWebhook failed: HTTP ${res.status} ${JSON.stringify(body)}`);
+  }
+  if (body.ok === false) {
+    throw new Error(
+      `Bunq mock could not POST webhook (target HTTP ${body.status ?? '?'}): ${body.responseSnippet ?? body.error ?? JSON.stringify(body)}`
+    );
+  }
+}
+
+/** Bunq payment_request_id after /games/admin/:id/payment-requests (primary registration row). */
+export async function getPaymentRequestIdForUserRegistration(gameId: number, userId: number): Promise<string | null> {
+  const result = await pool.query(
+    `select pr.payment_request_id::text as payment_request_id
+     from payment_requests pr
+     inner join game_registrations gr on gr.id = pr.game_registration_id
+     where gr.game_id = $1 and gr.user_id = $2 and gr.guest_name is null
+     order by pr.id desc
+     limit 1`,
+    [gameId, userId]
+  );
+  return (result.rows[0]?.payment_request_id as string) ?? null;
+}
+
 export async function closeDbPool() {
   await pool.end();
 }

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -292,6 +292,16 @@ export async function resetBunqMock(): Promise<void> {
   }
 }
 
+export async function markBunqRequestInquiryAccepted(requestInquiryId: string): Promise<void> {
+  const res = await fetch(`${BUNQ_MOCK_CONTROL_ORIGIN}/request-inquiries/${requestInquiryId}/mark-accepted`, {
+    method: 'POST',
+    headers: { 'X-Bunq-Mock-Control-Token': BUNQ_MOCK_CONTROL_TOKEN },
+  });
+  if (!res.ok) {
+    throw new Error(`markBunqRequestInquiryAccepted failed: HTTP ${res.status} ${await res.text()}`);
+  }
+}
+
 export async function deliverBunqRequestInquiryAcceptedWebhook(
   requestInquiryId: string,
   targetUrlOverride?: string
@@ -469,6 +479,48 @@ export async function sendPaymentRequestsViaUi(page: Page, password = BUNQ_E2E_P
   await submitSendPaymentRequestsPassword(page, password);
   await dismissPaymentRequestsSentDialog(page);
   await expect(page.getByText('Payments collected by')).toBeVisible({ timeout: 30_000 });
+}
+
+export async function submitCheckPaymentStatusForGame(page: Page, password = BUNQ_E2E_PASSWORD): Promise<void> {
+  const checkButton = page.locator('.check-payments-button');
+  await expect(checkButton).toBeVisible({ timeout: 30_000 });
+
+  await expect
+    .poll(
+      async () => {
+        await checkButton.click();
+        return page.locator('.password-dialog-overlay #password').isVisible();
+      },
+      { timeout: 15_000, message: 'password dialog should open for per-game payment check' }
+    )
+    .toBe(true);
+
+  await page.locator('.password-dialog-overlay #password').fill(password);
+  await page.locator('.password-dialog-overlay').getByRole('button', { name: 'Submit' }).click();
+}
+
+export async function dismissPaymentCheckCompletedDialog(page: Page): Promise<void> {
+  const dialog = page.locator('.dialog-overlay').filter({ hasText: 'Payment check completed' });
+  await expect(dialog).toBeVisible({ timeout: 60_000 });
+  await dialog.locator('.dialog-btn.ok').click();
+}
+
+export async function confirmDialog(page: Page): Promise<void> {
+  await page.locator('.dialog-overlay .dialog-btn.ok').click();
+}
+
+export async function togglePlayerPaidStatusViaUi(
+  page: Page,
+  displayName: string,
+  options?: { confirm?: boolean }
+): Promise<void> {
+  const confirm = options?.confirm ?? true;
+  const row = page.locator('.player-item').filter({ hasText: displayName });
+  await row.locator('.paid-status').click();
+  if (confirm) {
+    await expect(page.locator('.dialog-overlay .dialog-message')).toContainText(/Mark|Unmark/);
+    await confirmDialog(page);
+  }
 }
 
 export async function getPaymentRequestIdForUserRegistration(gameId: number, userId: number): Promise<string | null> {

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -241,20 +241,6 @@ export async function countRegistrations(gameId: number) {
   return result.rows[0].count as number;
 }
 
-export async function createAdminAssignment(dayOfWeek: number, withPositions: boolean, userId: number) {
-  const result = await pool.query(
-    `insert into game_administrators (day_of_week, with_positions, user_id)
-     values ($1,$2,$3)
-     returning id`,
-    [dayOfWeek, withPositions, userId]
-  );
-  return result.rows[0].id as number;
-}
-
-export async function setUserBlockReason(userId: number, blockReason: string | null) {
-  await pool.query(`update users set block_reason = $1 where id = $2`, [blockReason, userId]);
-}
-
 /** PUT /api/games/admin/:gameId — await immediately before clicking Save Changes on edit form. */
 export function waitForAdminGameUpdateResponse(page: Page, gameId: number) {
   return page.waitForResponse(

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -200,6 +200,11 @@ export async function findGameByTitle(title: string) {
   return result.rows[0] || null;
 }
 
+export async function findGameById(id: number) {
+  const result = await pool.query(`select * from games where id = $1`, [id]);
+  return result.rows[0] || null;
+}
+
 export async function updateGame(id: number, updates: Record<string, unknown>) {
   const entries = Object.entries(updates);
   if (entries.length === 0) return;
@@ -216,6 +221,11 @@ export async function registerUser(gameId: number, userId: number, createdAt: Da
     [gameId, userId, guestName ?? null, bringingTheBall, paid, createdAt]
   );
   return result.rows[0].id as number;
+}
+
+export async function countRegistrations(gameId: number) {
+  const result = await pool.query(`select count(*)::int as count from game_registrations where game_id = $1`, [gameId]);
+  return result.rows[0].count as number;
 }
 
 export async function createAdminAssignment(dayOfWeek: number, withPositions: boolean, userId: number) {

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -146,7 +146,7 @@ export function e2eTitle(testInfo: TestInfo, label: string) {
   return `E2E ${label} ${uniqueRunId(testInfo)}`;
 }
 
-function formatDateForInput(date: Date) {
+export function formatGameDateTimeForInput(date: Date) {
   const month = date.toLocaleString('en-US', { month: 'long' });
   const day = date.getDate();
   const year = date.getFullYear();
@@ -177,7 +177,7 @@ export async function createGameViaUi(page: Page, input: UiGameInput): Promise<G
 
   const dateTime = input.dateTime || daysFromNow(2);
   const dateInput = page.getByPlaceholder('Select date and time');
-  await dateInput.fill(formatDateForInput(dateTime));
+  await dateInput.fill(formatGameDateTimeForInput(dateTime));
   await dateInput.press('Enter');
   await page.locator('#maxPlayers').fill(String(input.maxPlayers ?? 14));
   await page.locator('#unregisterDeadlineHours').fill(String(input.unregisterDeadlineHours ?? 5));
@@ -249,6 +249,19 @@ export async function createAdminAssignment(dayOfWeek: number, withPositions: bo
     [dayOfWeek, withPositions, userId]
   );
   return result.rows[0].id as number;
+}
+
+export async function setUserBlockReason(userId: number, blockReason: string | null) {
+  await pool.query(`update users set block_reason = $1 where id = $2`, [blockReason, userId]);
+}
+
+/** PUT /api/games/admin/:gameId — await immediately before clicking Save Changes on edit form. */
+export function waitForAdminGameUpdateResponse(page: Page, gameId: number) {
+  return page.waitForResponse(
+    (response) =>
+      response.request().method() === 'PUT' &&
+      new URL(response.url()).pathname === `/api/games/admin/${gameId}`
+  );
 }
 
 export async function cleanupE2eData() {

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -179,6 +179,15 @@ export async function setCheckbox(page: Page, selector: string, checked = true) 
   }
 }
 
+/** POST /api/games/admin — call immediately before clicking Create Game. */
+export function waitForAdminGameCreateResponse(page: Page) {
+  return page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' &&
+      /\/api\/games\/admin$/.test(new URL(response.url()).pathname)
+  );
+}
+
 export async function createGameViaUi(page: Page, input: UiGameInput): Promise<GameFixture> {
   await page.goto('/games/new');
   await expect(page.getByRole('heading', { name: 'Create New Game' })).toBeVisible();
@@ -204,15 +213,19 @@ export async function createGameViaUi(page: Page, input: UiGameInput): Promise<G
     await setCheckbox(page, '#readonly');
   }
 
+  const createResponsePromise = waitForAdminGameCreateResponse(page);
   await page.getByRole('button', { name: 'Create Game' }).click();
+  const createResponse = await createResponsePromise;
+  expect(createResponse.ok()).toBeTruthy();
+  const body = (await createResponse.json()) as { id: number; title: string | null };
+  expect(body.id).toBeGreaterThan(0);
+
   await expect(page).toHaveURL('/');
 
-  const created = await findGameByTitle(input.title);
-  expect(created).toBeTruthy();
   return {
-    id: created.id,
-    title: created.title,
-    dateTime: new Date(created.date_time),
+    id: body.id,
+    title: body.title ?? input.title,
+    dateTime,
   };
 }
 
@@ -277,32 +290,12 @@ export async function createGame(input: GameInput): Promise<GameFixture> {
   };
 }
 
-export async function findGameByTitle(title: string) {
-  const result = await pool.query(`select * from games where title = $1 order by id desc limit 1`, [title]);
-  return result.rows[0] || null;
-}
-
-export async function findGameById(id: number) {
-  const result = await pool.query(`select * from games where id = $1`, [id]);
-  return result.rows[0] || null;
-}
-
 export async function updateGame(id: number, updates: Record<string, unknown>) {
   const entries = Object.entries(updates);
   if (entries.length === 0) return;
 
   const setSql = entries.map(([key], index) => `${key} = $${index + 2}`).join(', ');
   await pool.query(`update games set ${setSql} where id = $1`, [id, ...entries.map(([, value]) => value)]);
-}
-
-export async function registerUser(gameId: number, userId: number, createdAt: Date, guestName?: string, bringingTheBall = false, paid = false) {
-  const result = await pool.query(
-    `insert into game_registrations (game_id, user_id, guest_name, bringing_the_ball, paid, created_at)
-     values ($1,$2,$3,$4,$5,$6)
-     returning id`,
-    [gameId, userId, guestName ?? null, bringingTheBall, paid, createdAt]
-  );
-  return result.rows[0].id as number;
 }
 
 export async function countRegistrations(gameId: number) {

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -324,6 +324,56 @@ export async function deliverBunqRequestInquiryAcceptedWebhook(
 }
 
 /** Bunq payment_request_id after /games/admin/:id/payment-requests (primary registration row). */
+export const BUNQ_E2E_PASSWORD = 'BunqE2E!Pass9';
+export const BUNQ_E2E_API_KEY = 'e2e-bunq-api-key';
+export const BUNQ_E2E_API_KEY_NAME = 'E2E Bunq Client';
+
+export async function enableBunqIntegrationViaUi(page: Page): Promise<void> {
+  await page.goto('/bunq-settings');
+  await expect(page.getByRole('heading', { name: 'Bunq Settings' })).toBeVisible();
+  await expect(page.getByText('Loading...')).toHaveCount(0, { timeout: 30_000 });
+
+  if (await page.getByText(/Bunq integration is enabled/).isVisible().catch(() => false)) {
+    return;
+  }
+
+  await page.getByRole('button', { name: 'Enable Bunq Integration' }).click();
+  await page.locator('#apiKey').fill(BUNQ_E2E_API_KEY);
+  await page.locator('#apiKeyName').fill(BUNQ_E2E_API_KEY_NAME);
+  await page.locator('.credentials-form #password').fill(BUNQ_E2E_PASSWORD);
+  await page.getByRole('button', { name: 'Enable Integration' }).click();
+  await expect(page.getByText(/Bunq integration enabled successfully/i)).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByText(/Bunq integration is enabled/)).toBeVisible();
+}
+
+export async function moveGameToPastViaUi(page: Page, gameId: number, pastDate = daysFromNow(-2)): Promise<void> {
+  await page.goto(`/game/${gameId}/edit`);
+  await expect(page.getByRole('heading', { name: 'Edit Game Settings' })).toBeVisible();
+  const dateInput = page.getByPlaceholder('Select date and time');
+  await dateInput.fill(formatGameDateTimeForInput(pastDate));
+  await dateInput.press('Enter');
+  const updatePromise = waitForAdminGameUpdateResponse(page, gameId);
+  await page.getByRole('button', { name: 'Save Changes' }).click();
+  const updateResponse = await updatePromise;
+  expect(updateResponse.ok()).toBeTruthy();
+  if (page.url().includes('/edit')) {
+    await page.goto(`/game/${gameId}`);
+  }
+  await expect(page).toHaveURL(new RegExp(`/game/${gameId}$`));
+}
+
+export async function sendPaymentRequestsViaUi(page: Page): Promise<void> {
+  const sendBtn = page.getByTitle('Send payment requests to unpaid players');
+  await expect(sendBtn).toBeVisible({ timeout: 30_000 });
+  await sendBtn.click();
+  await page.locator('.password-dialog-overlay').getByLabel('Password:').fill(BUNQ_E2E_PASSWORD);
+  await page.locator('.password-dialog-overlay').getByRole('button', { name: 'Submit' }).click();
+  const paymentSentDialog = page.getByRole('dialog').filter({ hasText: 'Payment requests sent' });
+  await expect(paymentSentDialog.getByText(/payment requests sent successfully/i)).toBeVisible({ timeout: 60_000 });
+  await paymentSentDialog.getByRole('button', { name: 'OK' }).click();
+  await expect(page.getByText('Payments collected by')).toBeVisible({ timeout: 30_000 });
+}
+
 export async function getPaymentRequestIdForUserRegistration(gameId: number, userId: number): Promise<string | null> {
   const result = await pool.query(
     `select pr.payment_request_id::text as payment_request_id

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "typescript": "^5.9.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "concurrently": "^8.2.2"
       }
     },
@@ -22,6 +23,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-regex": {
@@ -177,6 +194,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -213,6 +245,38 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
-        "concurrently": "^8.2.2"
+        "@types/pg": "^8.20.0",
+        "concurrently": "^8.2.2",
+        "pg": "^8.20.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -39,6 +41,28 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -246,6 +270,103 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
@@ -276,6 +397,49 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-directory": {
@@ -316,6 +480,16 @@
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
       "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
       "dev": true
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -391,6 +565,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -407,6 +588,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "db:up": "docker compose up -d postgres",
     "db:down": "docker compose down",
     "db:logs": "docker compose logs -f postgres",
+    "bunq-mock:dev": "cd bunq-mock && npm run dev",
     "e2e:server": "bash scripts/playwright-dev-server.sh",
     "test:e2e": "playwright test",
     "test:e2e:auth": "playwright test e2e/auth-session.spec.ts"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,13 @@
     "build": "npm run backend:build && npm run tg-mini-app:build",
     "db:up": "docker compose up -d postgres",
     "db:down": "docker compose down",
-    "db:logs": "docker compose logs -f postgres"
+    "db:logs": "docker compose logs -f postgres",
+    "e2e:server": "bash scripts/playwright-dev-server.sh",
+    "test:e2e": "playwright test",
+    "test:e2e:auth": "playwright test e2e/auth-session.spec.ts"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "concurrently": "^8.2.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
-    "concurrently": "^8.2.2"
+    "@types/pg": "^8.20.0",
+    "concurrently": "^8.2.2",
+    "pg": "^8.20.0"
   },
   "dependencies": {
     "typescript": "^5.9.2"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     timeout: 10_000,
   },
   fullyParallel: false,
+  workers: 1,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: [['list'], ['html', { open: 'never' }]],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 45_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://127.0.0.1:3001',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  webServer: {
+    command: 'npm run e2e:server',
+    url: 'http://127.0.0.1:3001',
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/scripts/playwright-dev-server.sh
+++ b/scripts/playwright-dev-server.sh
@@ -11,6 +11,7 @@ export MINI_APP_URL="${MINI_APP_URL:-http://127.0.0.1:3001}"
 export JWT_SECRET="${JWT_SECRET:-playwright-dev-secret}"
 export PLAYWRIGHT_DOCKER_DATA_ROOT="${PLAYWRIGHT_DOCKER_DATA_ROOT:-/tmp/volley-game-central-playwright-docker-vfs}"
 export PLAYWRIGHT_DOCKER_LOG="${PLAYWRIGHT_DOCKER_LOG:-/tmp/volley-game-central-playwright-dockerd.log}"
+export PLAYWRIGHT_USE_HOST_NETWORK_POSTGRES="${PLAYWRIGHT_USE_HOST_NETWORK_POSTGRES:-false}"
 
 run_as_root() {
   if [ "$(id -u)" -eq 0 ]; then
@@ -58,6 +59,7 @@ start_dockerd_directly() {
   fi
 
   echo "Starting Docker daemon directly for Playwright E2E tests..."
+  export PLAYWRIGHT_USE_HOST_NETWORK_POSTGRES=true
   run_as_root mkdir -p "$PLAYWRIGHT_DOCKER_DATA_ROOT"
   run_as_root nohup dockerd \
     --host=unix:///var/run/docker.sock \
@@ -67,6 +69,21 @@ start_dockerd_directly() {
     --iptables=false \
     --ip6tables=false \
     >"$PLAYWRIGHT_DOCKER_LOG" 2>&1 &
+}
+
+start_postgres() {
+  if [ "$PLAYWRIGHT_USE_HOST_NETWORK_POSTGRES" = "true" ]; then
+    docker_cli rm -f volley-playwright-postgres >/dev/null 2>&1 || true
+    docker_cli run -d \
+      --name volley-playwright-postgres \
+      --network host \
+      -e POSTGRES_USER="$POSTGRES_USER" \
+      -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+      -e POSTGRES_DB="$POSTGRES_DB" \
+      postgres:15-alpine
+  else
+    docker_cli compose up -d postgres
+  fi
 }
 
 ensure_docker_daemon() {
@@ -104,7 +121,7 @@ ensure_docker_daemon() {
 install_docker_if_missing
 ensure_docker_daemon
 
-docker_cli compose up -d postgres
+start_postgres
 
 npm run backend:build
 npx concurrently "cd backend && npm run dev" "npm run tg-mini-app:dev"

--- a/scripts/playwright-dev-server.sh
+++ b/scripts/playwright-dev-server.sh
@@ -9,35 +9,57 @@ export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
 export POSTGRES_DB="${POSTGRES_DB:-volley_game_central}"
 export MINI_APP_URL="${MINI_APP_URL:-http://127.0.0.1:3001}"
 export JWT_SECRET="${JWT_SECRET:-playwright-dev-secret}"
-export PLAYWRIGHT_PGDATA="${PLAYWRIGHT_PGDATA:-/tmp/volley-game-central-playwright-pgdata}"
 
-if command -v docker >/dev/null 2>&1; then
-  docker compose up -d postgres
-else
-  pg_bindir="$(pg_config --bindir 2>/dev/null || true)"
-  if [ -n "$pg_bindir" ]; then
-    export PATH="$pg_bindir:$PATH"
+run_as_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    echo "This script needs root privileges to install or start Docker." >&2
+    exit 1
+  fi
+}
+
+install_docker_if_missing() {
+  if command -v docker >/dev/null 2>&1; then
+    return
   fi
 
-  if ! command -v initdb >/dev/null 2>&1 || ! command -v pg_ctl >/dev/null 2>&1 || ! command -v psql >/dev/null 2>&1; then
-    echo "Docker is not available and local PostgreSQL tools were not found." >&2
-    echo "Install PostgreSQL locally or run tests in an environment with Docker." >&2
+  if ! command -v apt-get >/dev/null 2>&1; then
+    echo "Docker is required for Playwright E2E tests, but docker and apt-get were not found." >&2
     exit 1
   fi
 
-  if [ ! -f "$PLAYWRIGHT_PGDATA/PG_VERSION" ]; then
-    initdb -D "$PLAYWRIGHT_PGDATA" -U "$POSTGRES_USER" -A trust
+  echo "Docker is not available; installing Docker for Playwright E2E tests..."
+  run_as_root apt-get update
+  run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io docker-compose-v2
+}
+
+ensure_docker_daemon() {
+  if docker info >/dev/null 2>&1; then
+    return
   fi
 
-  if ! pg_ctl -D "$PLAYWRIGHT_PGDATA" status >/dev/null 2>&1; then
-    pg_ctl -D "$PLAYWRIGHT_PGDATA" -o "-p $POSTGRES_PORT -h 127.0.0.1 -k $PLAYWRIGHT_PGDATA" -l "$PLAYWRIGHT_PGDATA/server.log" start
+  if command -v service >/dev/null 2>&1; then
+    run_as_root service docker start || true
   fi
 
-  db_exists="$(psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '$POSTGRES_DB'")"
-  if [ "$db_exists" != "1" ]; then
-    createdb -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" "$POSTGRES_DB"
+  if ! docker info >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1; then
+    run_as_root systemctl start docker || true
   fi
-fi
+
+  if ! docker info >/dev/null 2>&1; then
+    echo "Docker is installed, but the daemon is not reachable by the current user." >&2
+    echo "Start Docker or grant this user access to the Docker daemon, then rerun the tests." >&2
+    exit 1
+  fi
+}
+
+install_docker_if_missing
+ensure_docker_daemon
+
+docker compose up -d postgres
 
 npm run backend:build
 npx concurrently "cd backend && npm run dev" "npm run tg-mini-app:dev"

--- a/scripts/playwright-dev-server.sh
+++ b/scripts/playwright-dev-server.sh
@@ -39,6 +39,11 @@ install_docker_if_missing() {
   run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io docker-compose-v2
 }
 
+install_playwright_browser() {
+  echo "Ensuring Playwright Chromium is installed..."
+  npx playwright install chromium
+}
+
 docker_info_reachable() {
   docker info >/dev/null 2>&1 || {
     command -v sudo >/dev/null 2>&1 && sudo docker info >/dev/null 2>&1
@@ -118,6 +123,7 @@ ensure_docker_daemon() {
   fi
 }
 
+install_playwright_browser
 install_docker_if_missing
 ensure_docker_daemon
 

--- a/scripts/playwright-dev-server.sh
+++ b/scripts/playwright-dev-server.sh
@@ -9,7 +9,35 @@ export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
 export POSTGRES_DB="${POSTGRES_DB:-volley_game_central}"
 export MINI_APP_URL="${MINI_APP_URL:-http://127.0.0.1:3001}"
 export JWT_SECRET="${JWT_SECRET:-playwright-dev-secret}"
+export PLAYWRIGHT_PGDATA="${PLAYWRIGHT_PGDATA:-/tmp/volley-game-central-playwright-pgdata}"
 
-npm run db:up
+if command -v docker >/dev/null 2>&1; then
+  docker compose up -d postgres
+else
+  pg_bindir="$(pg_config --bindir 2>/dev/null || true)"
+  if [ -n "$pg_bindir" ]; then
+    export PATH="$pg_bindir:$PATH"
+  fi
+
+  if ! command -v initdb >/dev/null 2>&1 || ! command -v pg_ctl >/dev/null 2>&1 || ! command -v psql >/dev/null 2>&1; then
+    echo "Docker is not available and local PostgreSQL tools were not found." >&2
+    echo "Install PostgreSQL locally or run tests in an environment with Docker." >&2
+    exit 1
+  fi
+
+  if [ ! -f "$PLAYWRIGHT_PGDATA/PG_VERSION" ]; then
+    initdb -D "$PLAYWRIGHT_PGDATA" -U "$POSTGRES_USER" -A trust
+  fi
+
+  if ! pg_ctl -D "$PLAYWRIGHT_PGDATA" status >/dev/null 2>&1; then
+    pg_ctl -D "$PLAYWRIGHT_PGDATA" -o "-p $POSTGRES_PORT -h 127.0.0.1" -l "$PLAYWRIGHT_PGDATA/server.log" start
+  fi
+
+  db_exists="$(psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '$POSTGRES_DB'")"
+  if [ "$db_exists" != "1" ]; then
+    createdb -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" "$POSTGRES_DB"
+  fi
+fi
+
 npm run backend:build
-npm run dev
+npx concurrently "cd backend && npm run dev" "npm run tg-mini-app:dev"

--- a/scripts/playwright-dev-server.sh
+++ b/scripts/playwright-dev-server.sh
@@ -63,6 +63,8 @@ start_dockerd_directly() {
     --host=unix:///var/run/docker.sock \
     --data-root="$PLAYWRIGHT_DOCKER_DATA_ROOT" \
     --pidfile="$PLAYWRIGHT_DOCKER_DATA_ROOT/dockerd.pid" \
+    --iptables=false \
+    --ip6tables=false \
     >"$PLAYWRIGHT_DOCKER_LOG" 2>&1 &
 }
 

--- a/scripts/playwright-dev-server.sh
+++ b/scripts/playwright-dev-server.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 export DEV_MODE="${DEV_MODE:-true}"
-export POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+export POSTGRES_HOST="${POSTGRES_HOST:-127.0.0.1}"
 export POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 export POSTGRES_USER="${POSTGRES_USER:-postgres}"
 export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
@@ -30,7 +30,7 @@ else
   fi
 
   if ! pg_ctl -D "$PLAYWRIGHT_PGDATA" status >/dev/null 2>&1; then
-    pg_ctl -D "$PLAYWRIGHT_PGDATA" -o "-p $POSTGRES_PORT -h 127.0.0.1" -l "$PLAYWRIGHT_PGDATA/server.log" start
+    pg_ctl -D "$PLAYWRIGHT_PGDATA" -o "-p $POSTGRES_PORT -h 127.0.0.1 -k $PLAYWRIGHT_PGDATA" -l "$PLAYWRIGHT_PGDATA/server.log" start
   fi
 
   db_exists="$(psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '$POSTGRES_DB'")"

--- a/scripts/playwright-dev-server.sh
+++ b/scripts/playwright-dev-server.sh
@@ -9,6 +9,9 @@ export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
 export POSTGRES_DB="${POSTGRES_DB:-volley_game_central}"
 export MINI_APP_URL="${MINI_APP_URL:-http://127.0.0.1:3001}"
 export JWT_SECRET="${JWT_SECRET:-playwright-dev-secret}"
+export BUNQ_API_URL="${BUNQ_API_URL:-http://127.0.0.1:3998/v1}"
+export BUNQ_MOCK_WEBHOOK_TARGET="${BUNQ_MOCK_WEBHOOK_TARGET:-http://127.0.0.1:3001/webhooks/bunq}"
+export BUNQ_MOCK_CONTROL_TOKEN="${BUNQ_MOCK_CONTROL_TOKEN:-e2e-bunq-mock-secret}"
 export PLAYWRIGHT_DOCKER_DATA_ROOT="${PLAYWRIGHT_DOCKER_DATA_ROOT:-/tmp/volley-game-central-playwright-docker-vfs}"
 export PLAYWRIGHT_DOCKER_LOG="${PLAYWRIGHT_DOCKER_LOG:-/tmp/volley-game-central-playwright-dockerd.log}"
 export PLAYWRIGHT_USE_HOST_NETWORK_POSTGRES="${PLAYWRIGHT_USE_HOST_NETWORK_POSTGRES:-false}"
@@ -146,4 +149,5 @@ ensure_docker_daemon
 start_postgres
 
 npm run backend:build
-npx concurrently "cd backend && npm run dev" "npm run tg-mini-app:dev"
+(cd bunq-mock && npm install)
+npx concurrently "cd backend && npm run dev" "npm run tg-mini-app:dev" "npm run bunq-mock:dev"

--- a/scripts/playwright-dev-server.sh
+++ b/scripts/playwright-dev-server.sh
@@ -9,7 +9,7 @@ export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
 export POSTGRES_DB="${POSTGRES_DB:-volley_game_central}"
 export MINI_APP_URL="${MINI_APP_URL:-http://127.0.0.1:3001}"
 export JWT_SECRET="${JWT_SECRET:-playwright-dev-secret}"
-export PLAYWRIGHT_DOCKER_DATA_ROOT="${PLAYWRIGHT_DOCKER_DATA_ROOT:-/tmp/volley-game-central-playwright-docker}"
+export PLAYWRIGHT_DOCKER_DATA_ROOT="${PLAYWRIGHT_DOCKER_DATA_ROOT:-/tmp/volley-game-central-playwright-docker-vfs}"
 export PLAYWRIGHT_DOCKER_LOG="${PLAYWRIGHT_DOCKER_LOG:-/tmp/volley-game-central-playwright-dockerd.log}"
 
 run_as_root() {
@@ -63,6 +63,7 @@ start_dockerd_directly() {
     --host=unix:///var/run/docker.sock \
     --data-root="$PLAYWRIGHT_DOCKER_DATA_ROOT" \
     --pidfile="$PLAYWRIGHT_DOCKER_DATA_ROOT/dockerd.pid" \
+    --storage-driver=vfs \
     --iptables=false \
     --ip6tables=false \
     >"$PLAYWRIGHT_DOCKER_LOG" 2>&1 &

--- a/scripts/playwright-dev-server.sh
+++ b/scripts/playwright-dev-server.sh
@@ -58,6 +58,18 @@ docker_cli() {
   fi
 }
 
+detect_restricted_docker_daemon() {
+  local storage_driver
+  storage_driver="$(docker info --format '{{.Driver}}' 2>/dev/null || true)"
+  if [ -z "$storage_driver" ] && command -v sudo >/dev/null 2>&1; then
+    storage_driver="$(sudo docker info --format '{{.Driver}}' 2>/dev/null || true)"
+  fi
+
+  if [ "$storage_driver" = "vfs" ]; then
+    export PLAYWRIGHT_USE_HOST_NETWORK_POSTGRES=true
+  fi
+}
+
 start_dockerd_directly() {
   if ! command -v dockerd >/dev/null 2>&1; then
     return
@@ -77,8 +89,10 @@ start_dockerd_directly() {
 }
 
 start_postgres() {
+  docker_cli rm -f volley-playwright-postgres >/dev/null 2>&1 || true
+
   if [ "$PLAYWRIGHT_USE_HOST_NETWORK_POSTGRES" = "true" ]; then
-    docker_cli rm -f volley-playwright-postgres >/dev/null 2>&1 || true
+    docker_cli rm -f workspace-postgres-1 >/dev/null 2>&1 || true
     docker_cli run -d \
       --name volley-playwright-postgres \
       --network host \
@@ -93,6 +107,7 @@ start_postgres() {
 
 ensure_docker_daemon() {
   if docker_info_reachable; then
+    detect_restricted_docker_daemon
     return
   fi
 
@@ -110,6 +125,7 @@ ensure_docker_daemon() {
 
   for _ in $(seq 1 30); do
     if docker_info_reachable; then
+      detect_restricted_docker_daemon
       return
     fi
     sleep 1

--- a/scripts/playwright-dev-server.sh
+++ b/scripts/playwright-dev-server.sh
@@ -9,6 +9,8 @@ export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
 export POSTGRES_DB="${POSTGRES_DB:-volley_game_central}"
 export MINI_APP_URL="${MINI_APP_URL:-http://127.0.0.1:3001}"
 export JWT_SECRET="${JWT_SECRET:-playwright-dev-secret}"
+export PLAYWRIGHT_DOCKER_DATA_ROOT="${PLAYWRIGHT_DOCKER_DATA_ROOT:-/tmp/volley-game-central-playwright-docker}"
+export PLAYWRIGHT_DOCKER_LOG="${PLAYWRIGHT_DOCKER_LOG:-/tmp/volley-game-central-playwright-dockerd.log}"
 
 run_as_root() {
   if [ "$(id -u)" -eq 0 ]; then
@@ -36,8 +38,36 @@ install_docker_if_missing() {
   run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io docker-compose-v2
 }
 
-ensure_docker_daemon() {
+docker_info_reachable() {
+  docker info >/dev/null 2>&1 || {
+    command -v sudo >/dev/null 2>&1 && sudo docker info >/dev/null 2>&1
+  }
+}
+
+docker_cli() {
   if docker info >/dev/null 2>&1; then
+    docker "$@"
+  else
+    run_as_root docker "$@"
+  fi
+}
+
+start_dockerd_directly() {
+  if ! command -v dockerd >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "Starting Docker daemon directly for Playwright E2E tests..."
+  run_as_root mkdir -p "$PLAYWRIGHT_DOCKER_DATA_ROOT"
+  run_as_root nohup dockerd \
+    --host=unix:///var/run/docker.sock \
+    --data-root="$PLAYWRIGHT_DOCKER_DATA_ROOT" \
+    --pidfile="$PLAYWRIGHT_DOCKER_DATA_ROOT/dockerd.pid" \
+    >"$PLAYWRIGHT_DOCKER_LOG" 2>&1 &
+}
+
+ensure_docker_daemon() {
+  if docker_info_reachable; then
     return
   fi
 
@@ -45,13 +75,25 @@ ensure_docker_daemon() {
     run_as_root service docker start || true
   fi
 
-  if ! docker info >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1; then
+  if ! docker_info_reachable && command -v systemctl >/dev/null 2>&1; then
     run_as_root systemctl start docker || true
   fi
 
-  if ! docker info >/dev/null 2>&1; then
+  if ! docker_info_reachable; then
+    start_dockerd_directly
+  fi
+
+  for _ in $(seq 1 30); do
+    if docker_info_reachable; then
+      return
+    fi
+    sleep 1
+  done
+
+  if ! docker_info_reachable; then
     echo "Docker is installed, but the daemon is not reachable by the current user." >&2
     echo "Start Docker or grant this user access to the Docker daemon, then rerun the tests." >&2
+    echo "If dockerd was started directly, inspect: $PLAYWRIGHT_DOCKER_LOG" >&2
     exit 1
   fi
 }
@@ -59,7 +101,7 @@ ensure_docker_daemon() {
 install_docker_if_missing
 ensure_docker_daemon
 
-docker compose up -d postgres
+docker_cli compose up -d postgres
 
 npm run backend:build
 npx concurrently "cd backend && npm run dev" "npm run tg-mini-app:dev"

--- a/scripts/playwright-dev-server.sh
+++ b/scripts/playwright-dev-server.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DEV_MODE="${DEV_MODE:-true}"
+export POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+export POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+export POSTGRES_USER="${POSTGRES_USER:-postgres}"
+export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
+export POSTGRES_DB="${POSTGRES_DB:-volley_game_central}"
+export MINI_APP_URL="${MINI_APP_URL:-http://127.0.0.1:3001}"
+export JWT_SECRET="${JWT_SECRET:-playwright-dev-secret}"
+
+npm run db:up
+npm run backend:build
+npm run dev

--- a/tg-mini-app/src/components/game-details/WaitlistList.tsx
+++ b/tg-mini-app/src/components/game-details/WaitlistList.tsx
@@ -115,6 +115,19 @@ export const WaitlistList: React.FC<Props> = ({ registrations, currentUserId, is
                 );
               })()
             )}
+
+            {isAdmin && registration.userId !== currentUserId && onRemovePlayer && (
+              <div className="admin-player-actions" title="Remove player">
+                <RemovePlayerButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemovePlayer(registration.userId, registration.guestName || undefined);
+                  }}
+                  title="Remove player"
+                  disabled={false}
+                />
+              </div>
+            )}
           </div>
         </div>
       ))}

--- a/tg-mini-app/src/components/game-details/WaitlistList.tsx
+++ b/tg-mini-app/src/components/game-details/WaitlistList.tsx
@@ -115,19 +115,6 @@ export const WaitlistList: React.FC<Props> = ({ registrations, currentUserId, is
                 );
               })()
             )}
-
-            {isAdmin && registration.userId !== currentUserId && onRemovePlayer && (
-              <div className="admin-player-actions" title="Remove player">
-                <RemovePlayerButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onRemovePlayer(registration.userId, registration.guestName || undefined);
-                  }}
-                  title="Remove player"
-                  disabled={false}
-                />
-              </div>
-            )}
           </div>
         </div>
       ))}

--- a/tg-mini-app/src/viewmodels/GameDetailsViewModel.ts
+++ b/tg-mini-app/src/viewmodels/GameDetailsViewModel.ts
@@ -498,12 +498,6 @@ export class GameDetailsViewModel {
   handleRemovePlayerFromWaitingList(userId: number, guestName?: string): void {
     if (!this.state.gameData.game || this.state.action.isActionLoading) return;
 
-    const isGameAdmin = this.user.isAdmin || (this.state.gameData.game.isAssignedAdmin ?? false);
-    if (isGameAdmin && userId != this.user.id) {
-      this.removePlayer(this.state.gameData.game, userId, guestName);
-      return;
-    }
-
     this.confirmAndUnregister(this.state.gameData.game, guestName);
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces direct `fully_paid` database updates in E2E tests with the real payment flow: send payment requests through the UI, then deliver accepted-inquiry webhooks via the Bunq mock control API.

## Changes

- **`updateGame` → `updateGameTag`**: DB helper now only sets the game `tag` (used for seasonal game scenarios).
- **`markGameFullyPaidViaBunq`**: New helper that sends payment requests and delivers webhooks for each participant, then reloads the game page.
- **`E2E-BUNQ-PAY-008`** and **`E2E-HOME-009`**: Updated to register/add participants, enable Bunq, and mark the game fully paid through the mock instead of patching `fully_paid` in Postgres.

## Testing

- `npx playwright test e2e/bunq-pay.spec.ts -g "BUNQ-PAY-008"`
- `npx playwright test e2e/games-home.spec.ts -g "HOME-009"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ba95b31-f17b-4964-9909-2e2a01061d8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ba95b31-f17b-4964-9909-2e2a01061d8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

