### PR TITLE
Fix flaky E2E tests (form submit state and logout navigation)

### DIFF
--- a/e2e/game-form.spec.ts
+++ b/e2e/game-form.spec.ts
@@ -204,7 +204,8 @@ test.describe('game creation and editing scenarios', () => {
     await page.locator('#title').fill(updatedTitle);
     const updatePromise = waitForAdminGameUpdateResponse(page, game.id);
     await page.getByRole('button', { name: 'Save Changes' }).click();
-    await updatePromise;
+    const updateResponse = await updatePromise;
+    expect(updateResponse.ok()).toBeTruthy();
 
     await expect(page).toHaveURL(new RegExp(`/game/${game.id}$`));
     await expect(page.getByText(updatedTitle)).toBeVisible();

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -65,8 +65,11 @@ export function uniquePhoneLocal(testInfo: TestInfo, suffix: number) {
 }
 
 export async function openDevLogin(page: Page) {
-  await page.goto('/');
-  await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+  const welcomeHeading = page.getByRole('heading', { name: 'Welcome' });
+  if (!(await welcomeHeading.isVisible().catch(() => false))) {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+  }
+  await expect(welcomeHeading).toBeVisible();
   await page.getByRole('button', { name: 'Phone number' }).click();
   await expect(page.getByText('Dev mode: No SMS verification required')).toBeVisible();
 }
@@ -215,6 +218,7 @@ export async function createGameViaUi(page: Page, input: UiGameInput): Promise<G
 export async function switchToUser(page: Page, user: DevUser) {
   if (await page.getByRole('button', { name: 'Logout' }).isVisible().catch(() => false)) {
     await page.getByRole('button', { name: 'Logout' }).click();
+    await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
   }
   return devLoginAs(page, user);
 }

--- a/tg-mini-app/src/pages/CreateGame.tsx
+++ b/tg-mini-app/src/pages/CreateGame.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import LoadingSpinner from '../components/LoadingSpinner';
 import { BackButton } from '@twa-dev/sdk/react';
@@ -16,6 +16,8 @@ registerLocale('en-GB', enGB);
 
 const CreateGame: React.FC = () => {
   const [state, setState] = useState<GameFormState>(GameFormViewModel.getInitialState());
+  const stateRef = useRef(state);
+  stateRef.current = state;
   const navigate = useNavigate();
   const inTelegram = isTelegramApp();
 
@@ -34,7 +36,7 @@ const CreateGame: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await viewModel.handleSubmit(state, () => navigate('/'));
+    await viewModel.handleSubmit(stateRef.current, () => navigate('/'));
   };
   
   const handleCancel = useCallback(() => {

--- a/tg-mini-app/src/pages/CreateGame.tsx
+++ b/tg-mini-app/src/pages/CreateGame.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import LoadingSpinner from '../components/LoadingSpinner';
 import { BackButton } from '@twa-dev/sdk/react';
@@ -16,8 +16,6 @@ registerLocale('en-GB', enGB);
 
 const CreateGame: React.FC = () => {
   const [state, setState] = useState<GameFormState>(GameFormViewModel.getInitialState());
-  const stateRef = useRef(state);
-  stateRef.current = state;
   const navigate = useNavigate();
   const inTelegram = isTelegramApp();
 
@@ -36,7 +34,7 @@ const CreateGame: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await viewModel.handleSubmit(stateRef.current, () => navigate('/'));
+    await viewModel.handleSubmit(() => navigate('/'));
   };
   
   const handleCancel = useCallback(() => {

--- a/tg-mini-app/src/pages/EditGameSettings.tsx
+++ b/tg-mini-app/src/pages/EditGameSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import LoadingSpinner from '../components/LoadingSpinner';
 import { BackButton } from '@twa-dev/sdk/react';
@@ -18,8 +18,6 @@ const EditGameSettings: React.FC = () => {
   const { gameId } = useParams<{ gameId: string }>();
   const navigate = useNavigate();
   const [state, setState] = useState<GameFormState>(GameFormViewModel.getInitialState());
-  const stateRef = useRef(state);
-  stateRef.current = state;
   const inTelegram = isTelegramApp();
 
   // Create ViewModel instance
@@ -39,7 +37,7 @@ const EditGameSettings: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await viewModel.handleSubmit(stateRef.current, () => {
+    await viewModel.handleSubmit(() => {
       if (gameId) {
         navigate(`/game/${gameId}`);
       } else {

--- a/tg-mini-app/src/pages/EditGameSettings.tsx
+++ b/tg-mini-app/src/pages/EditGameSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import LoadingSpinner from '../components/LoadingSpinner';
 import { BackButton } from '@twa-dev/sdk/react';
@@ -18,6 +18,8 @@ const EditGameSettings: React.FC = () => {
   const { gameId } = useParams<{ gameId: string }>();
   const navigate = useNavigate();
   const [state, setState] = useState<GameFormState>(GameFormViewModel.getInitialState());
+  const stateRef = useRef(state);
+  stateRef.current = state;
   const inTelegram = isTelegramApp();
 
   // Create ViewModel instance
@@ -37,7 +39,7 @@ const EditGameSettings: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await viewModel.handleSubmit(state, () => {
+    await viewModel.handleSubmit(stateRef.current, () => {
       if (gameId) {
         navigate(`/game/${gameId}`);
       } else {

--- a/tg-mini-app/src/viewmodels/GameFormViewModel.ts
+++ b/tg-mini-app/src/viewmodels/GameFormViewModel.ts
@@ -26,12 +26,20 @@ export interface GameFormState {
 export type GameFormStateUpdater = (updates: Partial<GameFormState>) => void;
 
 export class GameFormViewModel {
-  private updateState: GameFormStateUpdater;
+  private readonly syncReactState: GameFormStateUpdater;
+  private formState: GameFormState;
   private gameId: number | null;
 
-  constructor(updateState: GameFormStateUpdater, gameId?: number) {
-    this.updateState = updateState;
+  constructor(syncReactState: GameFormStateUpdater, gameId?: number) {
+    this.formState = GameFormViewModel.getInitialState();
+    this.syncReactState = syncReactState;
     this.gameId = gameId || null;
+  }
+
+  /** Apply partial updates to ViewModel state and mirror them into React. */
+  private updateState(updates: Partial<GameFormState>): void {
+    this.formState = { ...this.formState, ...updates };
+    this.syncReactState(updates);
   }
 
   /**
@@ -204,48 +212,42 @@ export class GameFormViewModel {
   }
 
   /**
-   * Submit form (create or update)
+   * Submit form (create or update). Reads the ViewModel's form state so submit
+   * always matches the latest field values, even if React has not re-rendered yet.
    */
-  async handleSubmit(
-    currentState: GameFormState,
-    onSuccess: () => void
-  ): Promise<void> {
-    if (!currentState.selectedDate) {
+  async handleSubmit(onSuccess: () => void): Promise<void> {
+    if (!this.formState.selectedDate) {
       this.updateState({ error: 'Please select a date and time' });
       return;
     }
 
     if (this.gameId) {
-      // Update existing game
-      await this.updateGame(currentState, onSuccess);
+      await this.updateGame(onSuccess);
     } else {
-      // Create new game
-      await this.createGame(currentState, onSuccess);
+      await this.createGame(onSuccess);
     }
   }
 
   /**
    * Create a new game
    */
-  private async createGame(
-    currentState: GameFormState,
-    onSuccess: () => void
-  ): Promise<void> {
+  private async createGame(onSuccess: () => void): Promise<void> {
+    const { formState } = this;
     try {
       this.updateState({ isLoading: true, error: null });
       
       await gamesApi.createGame({
-        dateTime: currentState.selectedDate!.toISOString(),
-        maxPlayers: currentState.maxPlayers,
-        unregisterDeadlineHours: currentState.unregisterDeadlineHours,
-        paymentAmount: currentState.paymentAmount,
-        pricingMode: currentState.pricingMode,
-        withPositions: currentState.withPositions,
-        withPriorityPlayers: currentState.withPriorityPlayers,
-        readonly: currentState.readonly,
-        locationName: currentState.locationName || null,
-        locationLink: currentState.locationLink || null,
-        title: currentState.title || null,
+        dateTime: formState.selectedDate!.toISOString(),
+        maxPlayers: formState.maxPlayers,
+        unregisterDeadlineHours: formState.unregisterDeadlineHours,
+        paymentAmount: formState.paymentAmount,
+        pricingMode: formState.pricingMode,
+        withPositions: formState.withPositions,
+        withPriorityPlayers: formState.withPriorityPlayers,
+        readonly: formState.readonly,
+        locationName: formState.locationName || null,
+        locationLink: formState.locationLink || null,
+        title: formState.title || null,
       });
       
       this.updateState({ isLoading: false });
@@ -264,27 +266,25 @@ export class GameFormViewModel {
   /**
    * Update an existing game
    */
-  private async updateGame(
-    currentState: GameFormState,
-    onSuccess: () => void
-  ): Promise<void> {
+  private async updateGame(onSuccess: () => void): Promise<void> {
     if (!this.gameId) return;
+    const { formState } = this;
 
     try {
       this.updateState({ isSaving: true, error: null });
       
       await gamesApi.updateGame(this.gameId, {
-        dateTime: currentState.selectedDate!.toISOString(),
-        maxPlayers: currentState.maxPlayers,
-        unregisterDeadlineHours: currentState.unregisterDeadlineHours,
-        paymentAmount: currentState.paymentAmount,
-        pricingMode: currentState.pricingMode,
-        withPositions: currentState.withPositions,
-        withPriorityPlayers: currentState.withPriorityPlayers,
-        readonly: currentState.readonly,
-        locationName: currentState.locationName || null,
-        locationLink: currentState.locationLink || null,
-        title: currentState.title || null,
+        dateTime: formState.selectedDate!.toISOString(),
+        maxPlayers: formState.maxPlayers,
+        unregisterDeadlineHours: formState.unregisterDeadlineHours,
+        paymentAmount: formState.paymentAmount,
+        pricingMode: formState.pricingMode,
+        withPositions: formState.withPositions,
+        withPriorityPlayers: formState.withPriorityPlayers,
+        readonly: formState.readonly,
+        locationName: formState.locationName || null,
+        locationLink: formState.locationLink || null,
+        title: formState.title || null,
       });
       
       this.updateState({ isSaving: false });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ran the full Playwright E2E suite three times. Two issues showed up:

1. **E2E-FORM-010** (consistent failure): After sending payment requests, saving an edited game title returned HTTP 200 but still persisted the **original** title. The edit form’s submit handler closed over stale React state, so fast UI updates (e.g. from Playwright `fill`) were not always included in the PUT body.

2. **E2E-ADMIN-007** (flaky, 1/3 runs): `switchToUser` clicked Logout and immediately navigated to `/` while logout was still in flight, causing `net::ERR_ABORTED`.

## Changes

- **GameFormViewModel**: Maintain `formState` inside the ViewModel (updated on every field change) and read it on submit, instead of passing React `state` from the page (avoids stale closure; cleaner than `useRef`).
- **E2E fixtures**: After logout, wait for the Welcome heading before dev login; skip redundant `page.goto('/')` when already on the landing page.
- **E2E-FORM-010**: Assert the admin game update response is OK.

## Verification

Full suite (`npm run test:e2e`, 107 tests) passed **3/3** consecutive runs after the initial fixes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e89b446d-14f5-4a7e-a31b-98c4434d2ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e89b446d-14f5-4a7e-a31b-98c4434d2ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

