### PR TITLE
Add is_tc role for player level management

### DIFF
--- a/backend/drizzle/0033_add_is_tc_to_users.sql
+++ b/backend/drizzle/0033_add_is_tc_to_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "is_tc" boolean DEFAULT false NOT NULL;

--- a/backend/drizzle/0034_player_level_set_by.sql
+++ b/backend/drizzle/0034_player_level_set_by.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "users" ADD COLUMN "player_level_set_by_id" integer;
+ALTER TABLE "users" ADD COLUMN "player_level_set_at" timestamp;
+ALTER TABLE "users" ADD CONSTRAINT "users_player_level_set_by_id_users_id_fk" FOREIGN KEY ("player_level_set_by_id") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1763046570440,
       "tag": "0032_player_level",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "5",
+      "when": 1763146570440,
+      "tag": "0033_add_is_tc_to_users",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1763146570440,
       "tag": "0033_add_is_tc_to_users",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "5",
+      "when": 1763246570440,
+      "tag": "0034_player_level_set_by",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "start": "node dist/index.js",
     "generate": "drizzle-kit generate:pg --config=drizzle.config.ts",
     "migrate": "node dist/db/migrate.js",
-    "test:unit": "node --require ts-node/register --test src/domain/gameFormat.test.ts src/domain/playerLevel.test.ts src/domain/positionsGameRegistrationEligibility.test.ts",
+    "test:unit": "node --require ts-node/register --test src/domain/gameFormat.test.ts src/domain/playerLevel.test.ts src/domain/positionsGameRegistrationEligibility.test.ts src/domain/userRoles.test.ts",
     "wait-for-db": "ts-node scripts/wait-for-db.ts"
   },
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "start": "node dist/index.js",
     "generate": "drizzle-kit generate:pg --config=drizzle.config.ts",
     "migrate": "node dist/db/migrate.js",
-    "test:unit": "node --require ts-node/register --test src/domain/gameFormat.test.ts src/domain/playerLevel.test.ts src/domain/positionsGameRegistrationEligibility.test.ts src/domain/userRoles.test.ts",
+    "test:unit": "node --require ts-node/register --test src/domain/gameFormat.test.ts src/domain/playerLevel.test.ts src/domain/positionsGameRegistrationEligibility.test.ts src/domain/userRoles.test.ts src/utils/playerLevelUser.test.ts",
     "wait-for-db": "ts-node scripts/wait-for-db.ts"
   },
   "dependencies": {

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -13,6 +13,8 @@ export const users = pgTable('users', {
   isTc: boolean('is_tc').notNull().default(false),
   phoneNumber: varchar('phone_number', { length: 50 }),
   playerLevel: varchar('player_level', { length: 32 }),
+  playerLevelSetById: integer('player_level_set_by_id').references((): any => users.id, { onDelete: 'set null' }),
+  playerLevelSetAt: timestamp('player_level_set_at'),
   createdAt: timestamp('created_at').defaultNow(),
 });
 

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -10,6 +10,7 @@ export const users = pgTable('users', {
   blockReason: text('block_reason'),
   blockedById: integer('blocked_by_id').references((): any => users.id, { onDelete: 'set null' }),
   isAdmin: boolean('is_admin').notNull().default(false),
+  isTc: boolean('is_tc').notNull().default(false),
   phoneNumber: varchar('phone_number', { length: 50 }),
   playerLevel: varchar('player_level', { length: 32 }),
   createdAt: timestamp('created_at').defaultNow(),

--- a/backend/src/domain/userRoles.test.ts
+++ b/backend/src/domain/userRoles.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { canManagePlayerLevels } from './userRoles';
+
+describe('canManagePlayerLevels', () => {
+  it('allows global admins', () => {
+    assert.equal(canManagePlayerLevels({ isAdmin: true, isTc: false }), true);
+  });
+
+  it('allows TC users', () => {
+    assert.equal(canManagePlayerLevels({ isAdmin: false, isTc: true }), true);
+  });
+
+  it('denies regular users', () => {
+    assert.equal(canManagePlayerLevels({ isAdmin: false, isTc: false }), false);
+  });
+});

--- a/backend/src/domain/userRoles.ts
+++ b/backend/src/domain/userRoles.ts
@@ -1,0 +1,8 @@
+export type UserRoleFlags = {
+  isAdmin: boolean;
+  isTc: boolean;
+};
+
+export function canManagePlayerLevels(user: UserRoleFlags): boolean {
+  return user.isAdmin || user.isTc;
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ import './services/telegramService'; // Import to ensure the bot is initialized
 import cookieParser from 'cookie-parser';
 import { authMiddleware } from './middleware/auth';
 import { adminAuthMiddleware } from './middleware/adminAuth';
+import { tcOrAdminAuthMiddleware } from './middleware/tcOrAdminAuth';
 import { adminOrAssignedAdminMiddleware } from './middleware/adminOrAssignedAdmin';
 import { BUILD_TIMESTAMP } from './buildInfo.generated';
 import { POSITIONS_GAME_LEVEL_RESTRICTIONS_ENABLED } from './config/positionsGameLevelRestrictions';

--- a/backend/src/middleware/tcOrAdminAuth.ts
+++ b/backend/src/middleware/tcOrAdminAuth.ts
@@ -1,0 +1,18 @@
+import { Request, Response, NextFunction } from 'express';
+import { canManagePlayerLevels } from '../domain/userRoles';
+
+/**
+ * Allows global admins and TC users to manage player levels.
+ * Use after authMiddleware.
+ */
+export const tcOrAdminAuthMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  if (!req.user) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  if (!canManagePlayerLevels(req.user)) {
+    return res.status(403).json({ error: 'Player level management access required' });
+  }
+
+  next();
+};

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -309,7 +309,12 @@ router.post('/dev-login', async (req, res) => {
   }
 
   try {
-    const { phoneNumber, displayName, isAdmin } = req.body as { phoneNumber?: string; displayName?: string; isAdmin?: boolean };
+    const { phoneNumber, displayName, isAdmin, isTc } = req.body as {
+      phoneNumber?: string;
+      displayName?: string;
+      isAdmin?: boolean;
+      isTc?: boolean;
+    };
     
     if (!phoneNumber || typeof phoneNumber !== 'string') {
       return res.status(400).json({ error: 'phoneNumber is required' });
@@ -321,7 +326,10 @@ router.post('/dev-login', async (req, res) => {
 
     const normalizedPhoneNumber = normalizePhone(phoneNumber);
     const adminStatus = isAdmin === true;
-    logDevMode(`Dev login attempt for phone: ${normalizedPhoneNumber}, name: ${displayName}, admin: ${adminStatus}`);
+    const tcStatus = isTc === true;
+    logDevMode(
+      `Dev login attempt for phone: ${normalizedPhoneNumber}, name: ${displayName}, admin: ${adminStatus}, tc: ${tcStatus}`,
+    );
 
     // Find or create user
     const existingUsers = await db.select().from(users).where(eq(users.phoneNumber, normalizedPhoneNumber)).limit(1);
@@ -330,10 +338,10 @@ router.post('/dev-login', async (req, res) => {
     if (existingUsers.length > 0) {
       // User exists, update display name and admin status if different
       user = existingUsers[0];
-      if (user.displayName !== displayName || user.isAdmin !== adminStatus) {
+      if (user.displayName !== displayName || user.isAdmin !== adminStatus || user.isTc !== tcStatus) {
         const [updatedUser] = await db
           .update(users)
-          .set({ displayName, isAdmin: adminStatus })
+          .set({ displayName, isAdmin: adminStatus, isTc: tcStatus })
           .where(eq(users.id, user.id))
           .returning();
         user = updatedUser;
@@ -379,6 +387,7 @@ router.post('/dev-login', async (req, res) => {
         phoneNumber: user.phoneNumber,
         displayName: user.displayName,
         isAdmin: user.isAdmin,
+        isTc: user.isTc,
       },
     });
   } catch (err) {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -349,10 +349,11 @@ router.post('/dev-login', async (req, res) => {
           phoneNumber: normalizedPhoneNumber,
           displayName,
           isAdmin: adminStatus,
+          isTc: tcStatus,
         })
         .returning();
       user = newUser;
-      logDevMode(`Created new user ${user.id}: ${user.displayName}, admin: ${user.isAdmin}`);
+      logDevMode(`Created new user ${user.id}: ${user.displayName}, admin: ${user.isAdmin}, tc: ${user.isTc}`);
     }
 
     // Issue JWT cookie just like regular phone auth

--- a/backend/src/routes/games.ts
+++ b/backend/src/routes/games.ts
@@ -17,7 +17,14 @@ import {
   type GameFormat,
 } from '../domain/gameFormat';
 import type { PlayerLevel } from '../domain/playerLevel';
+import { canManagePlayerLevels } from '../domain/userRoles';
 import { evaluateRegistrationEligibility } from '../utils/registrationEligibility';
+import {
+  attachPlayerLevelMetadataToUser,
+  playerLevelMetadataJoin,
+  playerLevelMetadataSelect,
+  playerLevelSetter,
+} from '../utils/playerLevelUser';
 
 const router = Router();
 
@@ -493,8 +500,11 @@ router.get('/:gameId', async (req, res) => {
       }
     }
 
-    // Get registrations with user information joined
-    const registrations = await db
+    const parsedGameId = parseInt(gameId);
+    const isAssignedAdmin = await isUserAssignedToGameById(req.user.id, parsedGameId);
+    const includePlayerLevelMetadata = canManagePlayerLevels(req.user) || isAssignedAdmin;
+
+    let registrationQuery = db
       .select({
         id: gameRegistrations.id,
         gameId: gameRegistrations.gameId,
@@ -504,19 +514,53 @@ router.get('/:gameId', async (req, res) => {
         bringingTheBall: gameRegistrations.bringingTheBall,
         createdAt: gameRegistrations.createdAt,
         user: getUserSelectFields(),
+        ...(includePlayerLevelMetadata ? playerLevelMetadataSelect : {}),
       })
       .from(gameRegistrations)
-      .innerJoin(users, eq(gameRegistrations.userId, users.id))
-      .where(eq(gameRegistrations.gameId, parseInt(gameId)))
-      .orderBy(gameRegistrations.createdAt); // Order by registration time
+      .innerJoin(users, eq(gameRegistrations.userId, users.id));
 
-    // Add isWaitlist field dynamically based on registration order
-    const registrationsWithWaitlistStatus = registrations.map((reg, index) => ({
-      ...reg,
-      isWaitlist: index >= game[0].maxPlayers,
-    }));
+    if (includePlayerLevelMetadata) {
+      registrationQuery = registrationQuery.leftJoin(
+        playerLevelSetter,
+        playerLevelMetadataJoin(),
+      ) as typeof registrationQuery;
+    }
 
-    let isAssignedAdmin = await isUserAssignedToGameById(req.user.id, parseInt(gameId));
+    const registrations = await registrationQuery
+      .where(eq(gameRegistrations.gameId, parsedGameId))
+      .orderBy(gameRegistrations.createdAt);
+
+    const registrationsWithWaitlistStatus = registrations.map((reg, index) => {
+      const {
+        playerLevel,
+        playerLevelSetAt,
+        setterId,
+        setterDisplayName,
+        user,
+        ...rest
+      } = reg as typeof reg & {
+        playerLevel?: string | null;
+        playerLevelSetAt?: Date | null;
+        setterId?: number | null;
+        setterDisplayName?: string | null;
+        user: Record<string, unknown>;
+      };
+
+      const userPayload = includePlayerLevelMetadata
+        ? attachPlayerLevelMetadataToUser(user, {
+            playerLevel: playerLevel ?? null,
+            playerLevelSetAt: playerLevelSetAt ?? null,
+            setterId: setterId ?? null,
+            setterDisplayName: setterDisplayName ?? null,
+          }, true)
+        : user;
+
+      return {
+        ...rest,
+        user: userPayload,
+        isWaitlist: index >= game[0].maxPlayers,
+      };
+    });
 
     // Check if user is a priority player for this game (for frontend display)
     const isPriorityPlayer = await isUserPriorityPlayerForGame(req.user.id, gameRowForFormatHelpers(game[0]));

--- a/backend/src/routes/playerLevelsAdmin.ts
+++ b/backend/src/routes/playerLevelsAdmin.ts
@@ -7,36 +7,55 @@ import {
   isValidPlayerLevel,
   type PlayerLevel,
 } from '../domain/playerLevel';
+import {
+  mapPlayerLevelMetadata,
+  playerLevelMetadataJoin,
+  playerLevelMetadataSelect,
+  playerLevelSetter,
+} from '../utils/playerLevelUser';
+import { getUserSelectFields } from '../utils/dbQueryUtils';
 
 const router = Router();
+
+function mapListRow(
+  row: {
+    id: number;
+    displayName: string;
+    telegramUsername: string | null;
+    telegramId: string | null;
+    avatarUrl: string | null;
+    blockReason: string | null;
+    phoneNumber: string | null;
+    playerLevel: string | null;
+    playerLevelSetAt: Date | null;
+    setterId: number | null;
+    setterDisplayName: string | null;
+  },
+) {
+  const levelMeta = mapPlayerLevelMetadata(row);
+  return {
+    id: row.id,
+    displayName: row.displayName,
+    telegramUsername: row.telegramUsername,
+    telegramId: row.telegramId,
+    avatarUrl: row.avatarUrl,
+    blockReason: row.blockReason,
+    phoneNumber: row.phoneNumber,
+    ...levelMeta,
+  };
+}
 
 router.get('/', async (_req, res) => {
   try {
     const rows = await db
       .select({
-        id: users.id,
-        displayName: users.displayName,
-        telegramUsername: users.telegramUsername,
-        telegramId: users.telegramId,
-        avatarUrl: users.avatarUrl,
-        blockReason: users.blockReason,
-        phoneNumber: users.phoneNumber,
-        playerLevel: users.playerLevel,
+        ...getUserSelectFields(),
+        ...playerLevelMetadataSelect,
       })
-      .from(users);
+      .from(users)
+      .leftJoin(playerLevelSetter, playerLevelMetadataJoin());
 
-    const sorted = rows
-      .map((row) => ({
-        id: row.id,
-        displayName: row.displayName,
-        telegramUsername: row.telegramUsername,
-        telegramId: row.telegramId,
-        avatarUrl: row.avatarUrl,
-        blockReason: row.blockReason,
-        phoneNumber: row.phoneNumber,
-        playerLevel: (row.playerLevel as PlayerLevel | null) ?? null,
-      }))
-      .sort(compareUsersForPlayerLevelsList);
+    const sorted = rows.map(mapListRow).sort(compareUsersForPlayerLevelsList);
 
     res.json(sorted);
   } catch (error) {
@@ -45,8 +64,40 @@ router.get('/', async (_req, res) => {
   }
 });
 
+router.get('/:userId', async (req, res) => {
+  try {
+    const userId = parseInt(req.params.userId, 10);
+    if (Number.isNaN(userId)) {
+      return res.status(400).json({ error: 'Invalid userId' });
+    }
+
+    const rows = await db
+      .select({
+        ...getUserSelectFields(),
+        ...playerLevelMetadataSelect,
+      })
+      .from(users)
+      .leftJoin(playerLevelSetter, playerLevelMetadataJoin())
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    if (!rows.length) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    res.json(mapListRow(rows[0]));
+  } catch (error) {
+    console.error('Error fetching user for player levels:', error);
+    res.status(500).json({ error: 'Failed to fetch user' });
+  }
+});
+
 router.patch('/:userId/player-level', async (req, res) => {
   try {
+    if (!req.user) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
     const userId = parseInt(req.params.userId, 10);
     if (Number.isNaN(userId)) {
       return res.status(400).json({ error: 'Invalid userId' });
@@ -59,36 +110,31 @@ router.patch('/:userId/player-level', async (req, res) => {
       });
     }
 
-    const updated = await db
+    const setAt = new Date();
+    await db
       .update(users)
-      .set({ playerLevel })
-      .where(eq(users.id, userId))
-      .returning({
-        id: users.id,
-        displayName: users.displayName,
-        telegramUsername: users.telegramUsername,
-        telegramId: users.telegramId,
-        avatarUrl: users.avatarUrl,
-        blockReason: users.blockReason,
-        phoneNumber: users.phoneNumber,
-        playerLevel: users.playerLevel,
-      });
+      .set({
+        playerLevel,
+        playerLevelSetById: req.user.id,
+        playerLevelSetAt: setAt,
+      })
+      .where(eq(users.id, userId));
 
-    if (!updated.length) {
+    const rows = await db
+      .select({
+        ...getUserSelectFields(),
+        ...playerLevelMetadataSelect,
+      })
+      .from(users)
+      .leftJoin(playerLevelSetter, playerLevelMetadataJoin())
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    if (!rows.length) {
       return res.status(404).json({ error: 'User not found' });
     }
 
-    const row = updated[0];
-    res.json({
-      id: row.id,
-      displayName: row.displayName,
-      telegramUsername: row.telegramUsername,
-      telegramId: row.telegramId,
-      avatarUrl: row.avatarUrl,
-      blockReason: row.blockReason,
-      phoneNumber: row.phoneNumber,
-      playerLevel: row.playerLevel as PlayerLevel,
-    });
+    res.json(mapListRow(rows[0]));
   } catch (error) {
     console.error('Error updating player level:', error);
     res.status(500).json({ error: 'Failed to update player level' });

--- a/backend/src/utils/playerLevelUser.test.ts
+++ b/backend/src/utils/playerLevelUser.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mapPlayerLevelMetadata } from './playerLevelUser';
+
+describe('mapPlayerLevelMetadata', () => {
+  it('maps setter and timestamp when present', () => {
+    const result = mapPlayerLevelMetadata({
+      playerLevel: 'intermediate',
+      playerLevelSetAt: new Date('2026-05-20T10:00:00.000Z'),
+      setterId: 7,
+      setterDisplayName: 'Coach Ada',
+    });
+    assert.equal(result.playerLevel, 'intermediate');
+    assert.deepEqual(result.playerLevelSetBy, { id: 7, displayName: 'Coach Ada' });
+    assert.equal(result.playerLevelSetAt, '2026-05-20T10:00:00.000Z');
+  });
+
+  it('returns null metadata when level unset', () => {
+    const result = mapPlayerLevelMetadata({
+      playerLevel: null,
+      playerLevelSetAt: null,
+      setterId: null,
+      setterDisplayName: null,
+    });
+    assert.equal(result.playerLevel, null);
+    assert.equal(result.playerLevelSetBy, null);
+    assert.equal(result.playerLevelSetAt, null);
+  });
+});

--- a/backend/src/utils/playerLevelUser.ts
+++ b/backend/src/utils/playerLevelUser.ts
@@ -1,0 +1,56 @@
+import { alias } from 'drizzle-orm/pg-core';
+import { eq } from 'drizzle-orm';
+import { users } from '../db/schema';
+import type { PlayerLevel } from '../domain/playerLevel';
+
+export const playerLevelSetter = alias(users, 'player_level_setter');
+
+export type PlayerLevelSetBy = {
+  id: number;
+  displayName: string;
+};
+
+export type UserPlayerLevelMetadata = {
+  playerLevel: PlayerLevel | null;
+  playerLevelSetBy: PlayerLevelSetBy | null;
+  playerLevelSetAt: string | null;
+};
+
+type RowWithSetter = {
+  playerLevel: string | null;
+  playerLevelSetAt: Date | null;
+  setterId: number | null;
+  setterDisplayName: string | null;
+};
+
+export function mapPlayerLevelMetadata(row: RowWithSetter): UserPlayerLevelMetadata {
+  return {
+    playerLevel: (row.playerLevel as PlayerLevel | null) ?? null,
+    playerLevelSetBy:
+      row.setterId != null && row.setterDisplayName
+        ? { id: row.setterId, displayName: row.setterDisplayName }
+        : null,
+    playerLevelSetAt: row.playerLevelSetAt ? row.playerLevelSetAt.toISOString() : null,
+  };
+}
+
+export const playerLevelMetadataSelect = {
+  playerLevel: users.playerLevel,
+  playerLevelSetAt: users.playerLevelSetAt,
+  setterId: playerLevelSetter.id,
+  setterDisplayName: playerLevelSetter.displayName,
+} as const;
+
+export const playerLevelMetadataJoin = () =>
+  eq(users.playerLevelSetById, playerLevelSetter.id);
+
+export function attachPlayerLevelMetadataToUser<T extends Record<string, unknown>>(
+  user: T,
+  row: RowWithSetter,
+  includeMetadata: boolean,
+): T & Partial<UserPlayerLevelMetadata> {
+  if (!includeMetadata) {
+    return user;
+  }
+  return { ...user, ...mapPlayerLevelMetadata(row) };
+}

--- a/backend/src/utils/userPublic.ts
+++ b/backend/src/utils/userPublic.ts
@@ -1,5 +1,11 @@
-/** Strip internal player level from user payloads exposed outside global-admin player-levels routes. */
-export function omitPlayerLevel<T extends Record<string, unknown>>(user: T): Omit<T, 'playerLevel'> {
-  const { playerLevel: _removed, ...rest } = user;
+/** Strip player level metadata from user payloads for non-manager viewers. */
+export function omitPlayerLevel<T extends Record<string, unknown>>(user: T) {
+  const {
+    playerLevel: _playerLevel,
+    playerLevelSetBy: _playerLevelSetBy,
+    playerLevelSetAt: _playerLevelSetAt,
+    playerLevelSetById: _playerLevelSetById,
+    ...rest
+  } = user;
   return rest;
 }

--- a/e2e/player-levels.spec.ts
+++ b/e2e/player-levels.spec.ts
@@ -36,6 +36,7 @@ test.describe('player levels admin scenarios', () => {
     await expect(page.getByRole('heading', { name: 'Player details' })).toBeVisible();
     await page.locator('.player-level-select').selectOption('intermediate');
     await expect(page.locator('.player-level-select')).toHaveValue('intermediate');
+    await expect(page.getByText(/Set by/)).toContainText(admin.displayName);
 
     await page.getByRole('button', { name: 'Close' }).click();
     await expect(page.locator('.player-levels-item').filter({ hasText: target.displayName }).getByText('Intermediate')).toBeVisible();

--- a/e2e/player-levels.spec.ts
+++ b/e2e/player-levels.spec.ts
@@ -61,13 +61,13 @@ test.describe('player levels admin scenarios', () => {
     const target = await createDevUserViaApi(request, testInfo, 'Level TC Target');
 
     await devLoginAs(page, tcUser);
-    await page.getByTitle('Players').click();
-    await expect(page).toHaveURL('/players');
-    await expect(page.getByRole('link', { name: 'Player levels' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Game administrators' })).toHaveCount(0);
-
-    await page.getByRole('link', { name: 'Player levels' }).click();
+    await page.getByTitle('Player levels').click();
+    await expect(page).toHaveURL('/player-levels');
+    await expect(page.getByRole('heading', { name: 'Player levels' })).toBeVisible();
     await expect(page.getByText(target.displayName)).toBeVisible();
+
+    await page.goto('/players');
+    await expect(page).toHaveURL('/player-levels');
     await page.getByText(target.displayName).click();
     await page.locator('.player-level-select').selectOption('advanced');
     await expect(page.locator('.player-level-select')).toHaveValue('advanced');

--- a/e2e/player-levels.spec.ts
+++ b/e2e/player-levels.spec.ts
@@ -56,6 +56,26 @@ test.describe('player levels admin scenarios', () => {
     await expect(page.getByText(beta.displayName)).toHaveCount(0);
   });
 
+  test('E2E-LEVEL-005 TC user can manage player levels but not game administrators', async ({ page, request }, testInfo) => {
+    const tcUser = await createDevUserViaApi(request, testInfo, 'Level TC User', { isTc: true });
+    const target = await createDevUserViaApi(request, testInfo, 'Level TC Target');
+
+    await devLoginAs(page, tcUser);
+    await page.getByTitle('Players').click();
+    await expect(page).toHaveURL('/players');
+    await expect(page.getByRole('link', { name: 'Player levels' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Game administrators' })).toHaveCount(0);
+
+    await page.getByRole('link', { name: 'Player levels' }).click();
+    await expect(page.getByText(target.displayName)).toBeVisible();
+    await page.getByText(target.displayName).click();
+    await page.locator('.player-level-select').selectOption('advanced');
+    await expect(page.locator('.player-level-select')).toHaveValue('advanced');
+
+    await page.goto('/game-administrators');
+    await expect(page).toHaveURL('/');
+  });
+
   test('E2E-LEVEL-004 non-admin cannot access players hub or player levels', async ({ page, request }, testInfo) => {
     const participant = await createDevUserViaApi(request, testInfo, 'Level Blocked Participant');
     await devLoginAs(page, participant);

--- a/e2e/support/fixtures.ts
+++ b/e2e/support/fixtures.ts
@@ -6,6 +6,7 @@ export type DevUser = {
   displayName: string;
   phoneLocal: string;
   isAdmin: boolean;
+  isTc: boolean;
 };
 
 export type GameFixture = {

--- a/tg-mini-app/src/components/PlayerInfoDialog.tsx
+++ b/tg-mini-app/src/components/PlayerInfoDialog.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import './PlayerInfoDialog.scss';
 import type { PlayerLevel, UserPublicInfo } from '../types';
 import { PLAYER_LEVEL_LABELS } from '../utils/playerLevel';
-import { userApi, type UnpaidRegistration } from '../services/api';
+import { playerLevelsApi, userApi, type UnpaidRegistration } from '../services/api';
 import UnpaidGamesList from './UnpaidGamesList';
 
 // ViewModel encapsulating state and async loading logic for unpaid games
@@ -43,10 +43,18 @@ class PlayerInfoDialogViewModel {
   }
 }
 
+function formatPlayerLevelSetAt(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
 interface PlayerInfoDialogProps {
   isOpen: boolean;
   onClose: () => void;
   user: UserPublicInfo | null;
+  showPlayerLevelInfo?: boolean;
   showPlayerLevelEditor?: boolean;
   playerLevelSaving?: boolean;
   onPlayerLevelChange?: (level: PlayerLevel) => void | Promise<void>;
@@ -56,6 +64,7 @@ const PlayerInfoDialog: React.FC<PlayerInfoDialogProps> = ({
   isOpen,
   onClose,
   user,
+  showPlayerLevelInfo = false,
   showPlayerLevelEditor = false,
   playerLevelSaving = false,
   onPlayerLevelChange,
@@ -67,8 +76,10 @@ const PlayerInfoDialog: React.FC<PlayerInfoDialogProps> = ({
   const [reminderError, setReminderError] = useState<string | null>(null);
   const [blockReason, setBlockReason] = useState<string | null | undefined>(null);
   const [moderationBusy, setModerationBusy] = useState(false);
+  const [displayUser, setDisplayUser] = useState<UserPublicInfo | null>(null);
 
   const vm = useMemo(() => new PlayerInfoDialogViewModel(setUnpaidGames, setLoading, setError), []);
+  const showLevelSection = showPlayerLevelInfo || showPlayerLevelEditor;
 
   useEffect(() => {
     const onEsc = (e: KeyboardEvent) => {
@@ -91,10 +102,42 @@ const PlayerInfoDialog: React.FC<PlayerInfoDialogProps> = ({
     setBlockReason(user.blockReason ?? null);
     return () => vm.cancel();
   }, [isOpen, user?.id, vm]);
+  useEffect(() => {
+    if (!isOpen || !user) {
+      setDisplayUser(null);
+      return;
+    }
+    if (!showPlayerLevelInfo) {
+      setDisplayUser(user);
+      return;
+    }
+
+    let cancelled = false;
+    setDisplayUser(user);
+    (async () => {
+      try {
+        const details = await playerLevelsApi.getUser(user.id);
+        if (!cancelled) {
+          setDisplayUser({ ...user, ...details });
+        }
+      } catch {
+        if (!cancelled) {
+          setDisplayUser(user);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, user, showPlayerLevelInfo]);
+
 
   if (!isOpen || !user) return null;
 
-  const tmeLink = user.telegramUsername ? `https://t.me/${encodeURIComponent(user.telegramUsername)}` : undefined;
+  const profile = displayUser ?? user;
+
+  const tmeLink = profile.telegramUsername ? `https://t.me/${encodeURIComponent(profile.telegramUsername)}` : undefined;
 
   const handleSendReminder = async () => {
     if (!user) return;
@@ -152,65 +195,80 @@ const PlayerInfoDialog: React.FC<PlayerInfoDialogProps> = ({
         </div>
         <div className="dialog-content">
           <div className="avatar-wrap">
-            {user.avatarUrl ? (
-              <img src={user.avatarUrl} alt={`${user.displayName}'s avatar`} className="avatar" />
+            {profile.avatarUrl ? (
+              <img src={profile.avatarUrl} alt={`${profile.displayName}'s avatar`} className="avatar" />
             ) : (
-              <div className="avatar placeholder">{(user.displayName || user.telegramUsername || `Player ${user.id}`).charAt(0).toUpperCase()}</div>
+              <div className="avatar placeholder">{(profile.displayName || profile.telegramUsername || `Player ${profile.id}`).charAt(0).toUpperCase()}</div>
             )}
           </div>
           <div className="info-rows">
             <div className="row">
               <span className="label">Display Name</span>
-              <span className="value">{user.displayName || user.telegramUsername || `Player ${user.id}`}</span>
+              <span className="value">{profile.displayName || profile.telegramUsername || `Player ${profile.id}`}</span>
             </div>
             <div className="row">
               <span className="label">Telegram ID</span>
-              <span className="value">{user.telegramId}</span>
+              <span className="value">{profile.telegramId}</span>
             </div>
             {tmeLink && (
               <div className="row">
                 <span className="label">Telegram Username</span>
-                <a className="value link" href={tmeLink} target="_blank" rel="noopener noreferrer">@{user.telegramUsername}</a>
+                <a className="value link" href={tmeLink} target="_blank" rel="noopener noreferrer">@{profile.telegramUsername}</a>
               </div>
             )}
-            {user.phoneNumber && (
+            {profile.phoneNumber && (
               <div className="row">
                 <span className="label">Phone</span>
-                <a className="value link" href={`tel:${user.phoneNumber}`}>{user.phoneNumber}</a>
+                <a className="value link" href={`tel:${profile.phoneNumber}`}>{profile.phoneNumber}</a>
               </div>
             )}
           </div>
 
-          {showPlayerLevelEditor && onPlayerLevelChange && (
+          {showLevelSection && (
             <div className="player-level-editor" style={{ marginTop: 16 }}>
-              <div className="row" style={{ flexDirection: 'column', alignItems: 'stretch', gap: 8 }}>
-                <span className="label">Player level</span>
-                <select
-                  className="player-level-select"
-                  value={user.playerLevel ?? ''}
-                  disabled={playerLevelSaving}
-                  onChange={async (e) => {
-                    const value = e.target.value as PlayerLevel | '';
-                    if (!value || value === user.playerLevel) return;
-                    try {
-                      await onPlayerLevelChange(value);
-                    } catch {
-                      e.target.value = user.playerLevel ?? '';
-                    }
-                  }}
-                >
-                  {!user.playerLevel && <option value="">Unassigned — pick a level</option>}
-                  {(Object.keys(PLAYER_LEVEL_LABELS) as PlayerLevel[]).map((level) => (
-                    <option key={level} value={level}>
-                      {PLAYER_LEVEL_LABELS[level]}
-                    </option>
-                  ))}
-                </select>
-                {!user.playerLevel && (
-                  <span className="hint">Choose beginner, intermediate, or advanced to assign.</span>
-                )}
-                {playerLevelSaving && <span className="hint">Saving…</span>}
-              </div>
+              {showPlayerLevelEditor && onPlayerLevelChange ? (
+                <div className="row" style={{ flexDirection: 'column', alignItems: 'stretch', gap: 8 }}>
+                  <span className="label">Player level</span>
+                  <select
+                    className="player-level-select"
+                    value={profile.playerLevel ?? ''}
+                    disabled={playerLevelSaving}
+                    onChange={async (e) => {
+                      const value = e.target.value as PlayerLevel | '';
+                      if (!value || value === profile.playerLevel) return;
+                      try {
+                        await onPlayerLevelChange(value);
+                      } catch {
+                        e.target.value = profile.playerLevel ?? '';
+                      }
+                    }}
+                  >
+                    {!profile.playerLevel && <option value="">Unassigned — pick a level</option>}
+                    {(Object.keys(PLAYER_LEVEL_LABELS) as PlayerLevel[]).map((level) => (
+                      <option key={level} value={level}>
+                        {PLAYER_LEVEL_LABELS[level]}
+                      </option>
+                    ))}
+                  </select>
+                  {!profile.playerLevel && (
+                    <span className="hint">Choose beginner, intermediate, or advanced to assign.</span>
+                  )}
+                  {playerLevelSaving && <span className="hint">Saving…</span>}
+                </div>
+              ) : (
+                <div className="row">
+                  <span className="label">Player level</span>
+                  <span className="value">
+                    {profile.playerLevel ? PLAYER_LEVEL_LABELS[profile.playerLevel] : 'Unassigned'}
+                  </span>
+                </div>
+              )}
+              {profile.playerLevel && profile.playerLevelSetBy && (
+                <p className="hint" style={{ marginTop: 8 }}>
+                  Set by {profile.playerLevelSetBy.displayName}
+                  {profile.playerLevelSetAt ? ` on ${formatPlayerLevelSetAt(profile.playerLevelSetAt)}` : ''}
+                </p>
+              )}
             </div>
           )}
 

--- a/tg-mini-app/src/components/auth/PhoneAuth.tsx
+++ b/tg-mini-app/src/components/auth/PhoneAuth.tsx
@@ -161,7 +161,7 @@ class PhoneAuthViewModel {
     }
   }
 
-  async devLogin(displayName: string, isAdmin: boolean, onSuccess: () => void) {
+  async devLogin(displayName: string, isAdmin: boolean, isTc: boolean, onSuccess: () => void) {
     const name = displayName.trim();
     if (!name) {
       this.setState({ error: 'Please enter your name' });
@@ -219,7 +219,7 @@ function PhoneAuth({ onClose, isDevMode }: PhoneAuthProps) {
           onPhoneChange={(v) => viewModel.setPhoneLocal(v)}
           onContinue={() => viewModel.startAuth()}
           isDevMode={isDevMode}
-          onDevLogin={(name, isAdmin) => viewModel.devLogin(name, isAdmin, finishAuth)}
+          onDevLogin={(name, isAdmin, isTc) => viewModel.devLogin(name, isAdmin, isTc, finishAuth)}
         />
       )}
 

--- a/tg-mini-app/src/components/auth/PhoneAuth.tsx
+++ b/tg-mini-app/src/components/auth/PhoneAuth.tsx
@@ -173,7 +173,7 @@ class PhoneAuthViewModel {
     }
     try {
       this.setState({ isProcessing: true, error: null });
-      await authApi.devLogin(this.fullPhone, name, isAdmin);
+      await authApi.devLogin(this.fullPhone, name, isAdmin, isTc);
       onSuccess();
     } catch (e: any) {
       const message = e?.response?.data?.error || 'Dev login failed';

--- a/tg-mini-app/src/components/auth/PhoneStep.tsx
+++ b/tg-mini-app/src/components/auth/PhoneStep.tsx
@@ -72,6 +72,17 @@ const PhoneStep: React.FC<PhoneStepProps> = ({
             />
             <label htmlFor="wa-admin" style={{ cursor: 'pointer', fontSize: 14 }}>Administrator</label>
           </div>
+          <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 8 }}>
+            <input
+              id="wa-tc"
+              type="checkbox"
+              checked={isTc}
+              onChange={(e) => setIsTc(e.target.checked)}
+              disabled={isProcessing}
+              style={{ width: 18, height: 18, cursor: 'pointer' }}
+            />
+            <label htmlFor="wa-tc" style={{ cursor: 'pointer', fontSize: 14 }}>TC (player levels)</label>
+          </div>
           <p className="wa-note">Dev mode: No SMS verification required</p>
         </>
       ) : (

--- a/tg-mini-app/src/components/auth/PhoneStep.tsx
+++ b/tg-mini-app/src/components/auth/PhoneStep.tsx
@@ -8,7 +8,7 @@ interface PhoneStepProps {
   onPhoneChange: (val: string) => void;
   onContinue: () => void;
   isDevMode?: boolean;
-  onDevLogin?: (displayName: string, isAdmin: boolean) => void;
+  onDevLogin?: (displayName: string, isAdmin: boolean, isTc: boolean) => void;
 }
 
 const PhoneStep: React.FC<PhoneStepProps> = ({
@@ -23,6 +23,7 @@ const PhoneStep: React.FC<PhoneStepProps> = ({
 }) => {
   const [displayName, setDisplayName] = React.useState('');
   const [isAdmin, setIsAdmin] = React.useState(false);
+  const [isTc, setIsTc] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const nameInputRef = React.useRef<HTMLInputElement | null>(null);
   
@@ -99,7 +100,7 @@ const PhoneStep: React.FC<PhoneStepProps> = ({
             type="button"
             className="wa-button"
             disabled={!phoneLocal.trim() || !displayName.trim() || isProcessing}
-            onClick={() => onDevLogin(displayName, isAdmin)}
+            onClick={() => onDevLogin(displayName, isAdmin, isTc)}
           >
             {isProcessing ? 'Logging in…' : 'Dev Login'}
           </button>

--- a/tg-mini-app/src/pages/GameAdministrators.tsx
+++ b/tg-mini-app/src/pages/GameAdministrators.tsx
@@ -296,6 +296,7 @@ const GameAdministrators: React.FC = () => {
         isOpen={showPlayerInfo}
         onClose={handleClosePlayerInfo}
         user={selectedUser}
+        showPlayerLevelInfo={!!user?.isAdmin}
       />
     </div>
   );

--- a/tg-mini-app/src/pages/GameDetails.tsx
+++ b/tg-mini-app/src/pages/GameDetails.tsx
@@ -32,6 +32,7 @@ import { ActionLoadingOverlay } from "../components/game-details/ActionLoadingOv
 import { AdminActions } from "../components/game-details/AdminActions";
 import PlayerInfoDialog from "../components/PlayerInfoDialog";
 import CategoryInfoBlock from "../components/CategoryInfoBlock";
+import { canManagePlayerLevels } from "../utils/userRoles";
 
 interface GameDetailsProps {
   user: User;
@@ -133,6 +134,7 @@ const GameDetails: React.FC<GameDetailsProps> = ({ user }) => {
   const isPastGame = isGamePast(gameData.game.dateTime);
   const hasPaymentRequests = !!gameData.game.collectorUser;
   const isGameAdmin = user.isAdmin || (gameData.game.isAssignedAdmin ?? false);
+  const canViewPlayerLevelInfo = canManagePlayerLevels(user) || isGameAdmin;
   const showAddParticipantButton =
     isGameAdmin && !hasPaymentRequests && (isPastGame || gameData.game.readonly);
 
@@ -368,7 +370,7 @@ const GameDetails: React.FC<GameDetailsProps> = ({ user }) => {
               onRemovePlayer={(userId, guestName) => viewModel.handleRemovePlayer(userId, guestName)}
               onTogglePaidStatus={(userId, currentPaidStatus) => viewModel.handleTogglePaidStatus(userId, currentPaidStatus)}
               canUnregister={viewModel.canUnregister()}
-              onShowUserInfo={isGameAdmin ? (user) => viewModel.handleShowPlayerInfo(user) : undefined}
+              onShowUserInfo={canViewPlayerLevelInfo ? (u) => viewModel.handleShowPlayerInfo(u) : undefined}
             />
           </div>
         ) : null}
@@ -380,7 +382,7 @@ const GameDetails: React.FC<GameDetailsProps> = ({ user }) => {
               registrations={waitlistRegistrations}
               currentUserId={user.id}
               isAdmin={isGameAdmin}
-              onShowUserInfo={isGameAdmin ? (user) => viewModel.handleShowPlayerInfo(user) : undefined}
+              onShowUserInfo={canViewPlayerLevelInfo ? (u) => viewModel.handleShowPlayerInfo(u) : undefined}
               onRemovePlayer={(userId, guestName) => viewModel.handleRemovePlayerFromWaitingList(userId, guestName)}
             />
           </div>
@@ -451,6 +453,7 @@ const GameDetails: React.FC<GameDetailsProps> = ({ user }) => {
         isOpen={dialogs.showPlayerInfo}
         onClose={() => viewModel.handleClosePlayerInfo()}
         user={dialogs.selectedUser}
+        showPlayerLevelInfo={canViewPlayerLevelInfo}
       />
 
       {/* Bring Ball Dialog */}

--- a/tg-mini-app/src/pages/GamesList.tsx
+++ b/tg-mini-app/src/pages/GamesList.tsx
@@ -258,6 +258,7 @@ const GamesList: React.FC<GamesListProps> = ({ user }) => {
                     </div>
                     {user.isAdmin && (
                       <div className="admin-icon-buttons">
+                        {canManagePlayerLevels(user) && (
                         <Link
                           to="/players"
                           className="icon-button"
@@ -265,6 +266,7 @@ const GamesList: React.FC<GamesListProps> = ({ user }) => {
                         >
                           <FaUsers />
                         </Link>
+                        )}
                         <Link
                           to="/bunq-settings"
                           className="icon-button"

--- a/tg-mini-app/src/pages/GamesList.tsx
+++ b/tg-mini-app/src/pages/GamesList.tsx
@@ -12,6 +12,7 @@ import LoadingSpinner from '../components/LoadingSpinner';
 import UnpaidGamesList from '../components/UnpaidGamesList';
 import CategoryMultiSelect from '../components/CategoryMultiSelect';
 import CategoryInfoBlock from '../components/CategoryInfoBlock';
+import { isTcOnly, playersManagementPath } from '../utils/userRoles';
 import './GamesList.scss';
 
 interface GamesListProps {
@@ -229,6 +230,19 @@ const GamesList: React.FC<GamesListProps> = ({ user }) => {
               </div>
             )}
             
+
+            {isTcOnly(user) && (
+              <div className="admin-icon-buttons tc-player-levels-actions">
+                <Link
+                  to={playersManagementPath(user)}
+                  className="icon-button"
+                  title="Player levels"
+                >
+                  <FaUsers />
+                </Link>
+              </div>
+            )}
+
             {/* Admin controls */}
               {(user.isAdmin || vm.hasAdminAssignments) && (
                 <div className="admin-controls">
@@ -258,7 +272,6 @@ const GamesList: React.FC<GamesListProps> = ({ user }) => {
                     </div>
                     {user.isAdmin && (
                       <div className="admin-icon-buttons">
-                        {canManagePlayerLevels(user) && (
                         <Link
                           to="/players"
                           className="icon-button"
@@ -266,7 +279,6 @@ const GamesList: React.FC<GamesListProps> = ({ user }) => {
                         >
                           <FaUsers />
                         </Link>
-                        )}
                         <Link
                           to="/bunq-settings"
                           className="icon-button"

--- a/tg-mini-app/src/pages/PlayerLevels.tsx
+++ b/tg-mini-app/src/pages/PlayerLevels.tsx
@@ -89,7 +89,7 @@ const PlayerLevels: React.FC = () => {
     }
   };
 
-  if (user && !user.isAdmin) {
+  if (user && !canManagePlayerLevels(user)) {
     return null;
   }
 

--- a/tg-mini-app/src/pages/PlayerLevels.tsx
+++ b/tg-mini-app/src/pages/PlayerLevels.tsx
@@ -76,7 +76,7 @@ const PlayerLevels: React.FC = () => {
       setUsers((prev) =>
         prev.map((u) => (u.id === updated.id ? { ...u, ...updated } : u)),
       );
-      setSelectedUser((prev) => (prev ? { ...prev, playerLevel: updated.playerLevel } : prev));
+      setSelectedUser((prev) => (prev ? { ...prev, ...updated } : prev));
     } catch (e: unknown) {
       const message =
         (e as { response?: { data?: { error?: string } } })?.response?.data?.error ||
@@ -163,6 +163,7 @@ const PlayerLevels: React.FC = () => {
         isOpen={showPlayerInfo}
         onClose={handleClosePlayerInfo}
         user={selectedUser}
+        showPlayerLevelInfo
         showPlayerLevelEditor
         playerLevelSaving={levelSaving}
         onPlayerLevelChange={handlePlayerLevelChange}

--- a/tg-mini-app/src/pages/PlayerLevels.tsx
+++ b/tg-mini-app/src/pages/PlayerLevels.tsx
@@ -7,6 +7,7 @@ import { playerLevelsApi } from '../services/api';
 import type { AdminUserWithPlayerLevel, PlayerLevel, UserPublicInfo } from '../types';
 import PlayerInfoDialog from '../components/PlayerInfoDialog';
 import { PLAYER_LEVEL_LABELS, playerLevelPillClass } from '../utils/playerLevel';
+import { canManagePlayerLevels } from '../utils/userRoles';
 import './PlayerLevels.scss';
 
 const PlayerLevels: React.FC = () => {
@@ -39,11 +40,11 @@ const PlayerLevels: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (user && !user.isAdmin) {
+    if (user && !canManagePlayerLevels(user)) {
       navigate('/');
       return;
     }
-    if (user?.isAdmin) {
+    if (user && canManagePlayerLevels(user)) {
       loadUsers();
     }
   }, [user, navigate, loadUsers]);

--- a/tg-mini-app/src/pages/Players.tsx
+++ b/tg-mini-app/src/pages/Players.tsx
@@ -27,9 +27,11 @@ const Players: React.FC = () => {
         <h1>Players</h1>
       </div>
       <nav className="players-hub-links">
-        <Link to="/game-administrators" className="players-hub-link">
-          Game administrators
-        </Link>
+        {user?.isAdmin && (
+          <Link to="/game-administrators" className="players-hub-link">
+            Game administrators
+          </Link>
+        )}
         <Link to="/player-levels" className="players-hub-link">
           Player levels
         </Link>

--- a/tg-mini-app/src/pages/Players.tsx
+++ b/tg-mini-app/src/pages/Players.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { BackButton } from '@twa-dev/sdk/react';
 import { useAuthenticatedUser } from '../hooks/useAuthenticatedUser';
 import { isTelegramApp } from '../utils/telegram';
+import { canManagePlayerLevels, isTcOnly } from '../utils/userRoles';
 import './Players.scss';
 
 const Players: React.FC = () => {
@@ -11,12 +12,17 @@ const Players: React.FC = () => {
   const inTelegram = isTelegramApp();
 
   useEffect(() => {
-    if (user && !user.isAdmin) {
+    if (!user) return;
+    if (isTcOnly(user)) {
+      navigate('/player-levels', { replace: true });
+      return;
+    }
+    if (!canManagePlayerLevels(user)) {
       navigate('/');
     }
   }, [user, navigate]);
 
-  if (user && !user.isAdmin) {
+  if (!user || isTcOnly(user) || !user.isAdmin) {
     return null;
   }
 
@@ -27,11 +33,9 @@ const Players: React.FC = () => {
         <h1>Players</h1>
       </div>
       <nav className="players-hub-links">
-        {user?.isAdmin && (
-          <Link to="/game-administrators" className="players-hub-link">
-            Game administrators
-          </Link>
-        )}
+        <Link to="/game-administrators" className="players-hub-link">
+          Game administrators
+        </Link>
         <Link to="/player-levels" className="players-hub-link">
           Player levels
         </Link>

--- a/tg-mini-app/src/pages/PriorityPlayers.tsx
+++ b/tg-mini-app/src/pages/PriorityPlayers.tsx
@@ -10,6 +10,7 @@ import {
 } from '../viewmodels/PriorityPlayersViewModel';
 import PlayerInfoDialog from '../components/PlayerInfoDialog';
 import type { UserPublicInfo } from '../types';
+import { canManagePlayerLevels } from '../utils/userRoles';
 import './PriorityPlayers.scss';
 import WebApp from '@twa-dev/sdk';
 import { DAYS_OF_WEEK } from '../utils/constants';
@@ -277,6 +278,7 @@ const PriorityPlayers: React.FC = () => {
         isOpen={showPlayerInfo}
         onClose={handleClosePlayerInfo}
         user={selectedUser}
+        showPlayerLevelInfo={!!user && (user.isAdmin || canManagePlayerLevels(user))}
       />
     </div>
   );

--- a/tg-mini-app/src/services/api.ts
+++ b/tg-mini-app/src/services/api.ts
@@ -527,9 +527,10 @@ export const authApi = {
   devLogin: async (
     phoneNumber: string,
     displayName: string,
-    isAdmin?: boolean
+    isAdmin?: boolean,
+    isTc?: boolean,
   ): Promise<{ success: boolean; user: User }> => {
-    const response = await api.post('/auth/dev-login', { phoneNumber, displayName, isAdmin }, {
+    const response = await api.post('/auth/dev-login', { phoneNumber, displayName, isAdmin, isTc }, {
       withCredentials: true,
     });
     return response.data;

--- a/tg-mini-app/src/services/api.ts
+++ b/tg-mini-app/src/services/api.ts
@@ -126,6 +126,11 @@ export const playerLevelsApi = {
     return response.data;
   },
 
+  getUser: async (userId: number): Promise<AdminUserWithPlayerLevel> => {
+    const response = await api.get(`/users/admin/player-levels/${userId}`);
+    return response.data;
+  },
+
   updatePlayerLevel: async (userId: number, playerLevel: PlayerLevel): Promise<AdminUserWithPlayerLevel> => {
     const response = await api.patch(`/users/admin/player-levels/${userId}/player-level`, { playerLevel });
     return response.data;

--- a/tg-mini-app/src/types/index.ts
+++ b/tg-mini-app/src/types/index.ts
@@ -29,6 +29,7 @@ export interface User {
   displayName: string;
   telegramUsername?: string | null;
   isAdmin: boolean;
+  isTc: boolean;
   createdAt: Date | null;
   blockReason?: string | null;
 }

--- a/tg-mini-app/src/types/index.ts
+++ b/tg-mini-app/src/types/index.ts
@@ -7,6 +7,11 @@ export type GameFormat = 'recreational' | 'positions' | 'priority_players';
 
 export type PlayerLevel = 'beginner' | 'intermediate' | 'advanced';
 
+export interface PlayerLevelSetBy {
+  id: number;
+  displayName: string;
+}
+
 // Minimal user info used across UI for player dialogs and click handlers
 export interface UserPublicInfo {
   id: number;
@@ -17,6 +22,8 @@ export interface UserPublicInfo {
   blockReason?: string | null;
   phoneNumber?: string | null;
   playerLevel?: PlayerLevel | null;
+  playerLevelSetBy?: PlayerLevelSetBy | null;
+  playerLevelSetAt?: string | null;
 }
 
 export interface AdminUserWithPlayerLevel extends UserPublicInfo {

--- a/tg-mini-app/src/utils/userRoles.ts
+++ b/tg-mini-app/src/utils/userRoles.ts
@@ -3,3 +3,12 @@ import type { User } from '../types';
 export function canManagePlayerLevels(user: Pick<User, 'isAdmin' | 'isTc'>): boolean {
   return user.isAdmin || user.isTc;
 }
+
+export function isTcOnly(user: Pick<User, 'isAdmin' | 'isTc'>): boolean {
+  return user.isTc && !user.isAdmin;
+}
+
+/** Global admins use the Players hub; TC-only users go straight to player levels. */
+export function playersManagementPath(user: Pick<User, 'isAdmin' | 'isTc'>): '/players' | '/player-levels' {
+  return user.isAdmin ? '/players' : '/player-levels';
+}

--- a/tg-mini-app/src/utils/userRoles.ts
+++ b/tg-mini-app/src/utils/userRoles.ts
@@ -1,0 +1,5 @@
+import type { User } from '../types';
+
+export function canManagePlayerLevels(user: Pick<User, 'isAdmin' | 'isTc'>): boolean {
+  return user.isAdmin || user.isTc;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces a **TC** (`is_tc`) user flag and player level audit metadata so designated team captains can manage player levels without full global admin access.

## Changes

- **Database**
  - `users.is_tc` — TC role flag
  - `users.player_level_set_by_id`, `users.player_level_set_at` — who last set a player's level and when
- **API**
  - `/users/admin/player-levels` — list/get/patch with setter metadata; PATCH records `req.user` as setter
  - Game details include level metadata on registration users for global admins, TCs, and assigned game admins
- **Navigation**
  - Global admins use the Players hub; TC-only users go directly to `/player-levels`
- **Player info dialog**
  - Admins and TCs see player level (read-only or editable) and “Set by {name} on {date}” wherever the dialog is used
- **Dev login**: TC checkbox for local testing

## Granting roles in production

```sql
UPDATE users SET is_tc = true WHERE id = <user_id>;
```

## Verify

1. Run migrations through `0034_player_level_set_by.sql`
2. `cd backend && npm run test:unit`
3. `npm run test:e2e -- e2e/player-levels.spec.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ce6216b-1ec3-4f2a-bd51-d446e9c7cbc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ce6216b-1ec3-4f2a-bd51-d446e9c7cbc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

