### PR TITLE
chore(ralph): remove unused stateDir config field

### DIFF
--- a/.ralph/ralph.config.example.json
+++ b/.ralph/ralph.config.example.json
@@ -7,7 +7,6 @@
   "prd": "docs/prd/my-epic.md",
   "context": "CONTEXT.md",
   "e2e": "docs/playwright-e2e-scenarios.md",
-  "stateDir": ".ralph",
   "promptsDir": ".ralph/prompts",
   "worker": "remote-cursor",
   "push": true,

--- a/.ralph/ralph.config.json
+++ b/.ralph/ralph.config.json
@@ -7,7 +7,6 @@
   "prd": "docs/prd/player-levels-and-game-format.md",
   "context": "CONTEXT.md",
   "e2e": "docs/playwright-e2e-scenarios.md",
-  "stateDir": ".ralph",
   "promptsDir": ".ralph/prompts",
   "worker": "remote-cursor",
   "push": true,


### PR DESCRIPTION
## Summary
- remove the unused `stateDir` key from `.ralph/ralph.config.json`
- remove the unused `stateDir` key from `.ralph/ralph.config.example.json`

## Validation
- `ripgrep "stateDir" /workspace/volley-game-central` (no matches)
- `jq empty /workspace/volley-game-central/.ralph/ralph.config.json /workspace/volley-game-central/.ralph/ralph.config.example.json`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://app.warp.dev/conversation/f8e00797-d90b-4aa4-8776-e2928e1cb762_
_Run: https://oz.warp.dev/runs/019e9738-a6f7-7b66-890f-1df960e4b9dd_
_This PR was generated with [Oz](https://warp.dev/oz)._
